### PR TITLE
Contract local role `contract_supplier` for signing

### DIFF
--- a/src/openprocurement/api/models.py
+++ b/src/openprocurement/api/models.py
@@ -673,7 +673,7 @@ class Contract(Model):
     description = StringType()  # Contract description
     description_en = StringType()
     description_ru = StringType()
-    status = StringType(choices=["pending", "pending.winnerSigning", "terminated", "active", "cancelled"], default="pending")
+    status = StringType(choices=["pending", "pending.winner-signing", "terminated", "active", "cancelled"], default="pending")
     period = ModelType(Period)
     value = ModelType(Value)
     dateSigned = IsoDateTimeType()

--- a/src/openprocurement/api/models.py
+++ b/src/openprocurement/api/models.py
@@ -673,7 +673,7 @@ class Contract(Model):
     description = StringType()  # Contract description
     description_en = StringType()
     description_ru = StringType()
-    status = StringType(choices=["pending", "terminated", "active", "cancelled"], default="pending")
+    status = StringType(choices=["pending", "pending.winnerSigning", "terminated", "active", "cancelled"], default="pending")
     period = ModelType(Period)
     value = ModelType(Value)
     dateSigned = IsoDateTimeType()

--- a/src/openprocurement/tender/belowthreshold/tests/contract.py
+++ b/src/openprocurement/tender/belowthreshold/tests/contract.py
@@ -30,6 +30,9 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     lot2_patch_tender_contract_document,
     patch_tender_contract_value_vat_not_included,
     patch_tender_contract_value,
+    patch_tender_contract_status_by_owner,
+    patch_tender_contract_status_by_supplier,
+    patch_tender_contract_status_by_others,
 )
 
 
@@ -82,6 +85,9 @@ class TenderContractResourceTest(TenderContentWebTest, TenderContractResourceTes
     test_create_tender_contract_in_complete_status = snitch(create_tender_contract_in_complete_status)
     test_patch_tender_contract = snitch(patch_tender_contract)
     test_patch_tender_contract_value = snitch(patch_tender_contract_value)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
 
 
 class TenderContractVATNotIncludedResourceTest(TenderContentWebTest, TenderContractResourceTestMixin):
@@ -119,6 +125,9 @@ class TenderContractVATNotIncludedResourceTest(TenderContentWebTest, TenderContr
         self.create_award()
 
     test_patch_tender_contract_value_vat_not_included = snitch(patch_tender_contract_value_vat_not_included)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
 
 
 class Tender2LotContractResourceTest(TenderContentWebTest):

--- a/src/openprocurement/tender/belowthreshold/tests/contract.py
+++ b/src/openprocurement/tender/belowthreshold/tests/contract.py
@@ -33,6 +33,15 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_status_by_owner,
     patch_tender_contract_status_by_supplier,
     patch_tender_contract_status_by_others,
+    create_tender_contract_document_by_supplier,
+    create_tender_contract_document_by_others,
+    put_tender_contract_document_by_supplier,
+    put_tender_contract_document_by_others,
+    patch_tender_contract_document_by_supplier,
+    lot2_create_tender_contract_document_by_supplier,
+    lot2_create_tender_contract_document_by_others,
+    lot2_put_tender_contract_document_by_supplier,
+    lot2_patch_tender_contract_document_by_supplier,
 )
 
 
@@ -198,6 +207,12 @@ class TenderContractDocumentResourceTest(TenderContentWebTest, TenderContractDoc
         self.contract_id = contract["id"]
         self.app.authorization = auth
 
+    test_create_tender_contract_document_by_supplier = snitch(create_tender_contract_document_by_supplier)
+    test_create_tender_contract_document_by_others = snitch(create_tender_contract_document_by_others)
+    test_put_tender_contract_document_by_supplier = snitch(put_tender_contract_document_by_supplier)
+    test_put_tender_contract_document_by_others = snitch(put_tender_contract_document_by_others)
+    test_patch_tender_contract_document_by_supplier = snitch(patch_tender_contract_document_by_supplier)
+
 
 class Tender2LotContractDocumentResourceTest(TenderContentWebTest):
     initial_status = "active.qualification"
@@ -240,15 +255,21 @@ class Tender2LotContractDocumentResourceTest(TenderContentWebTest):
         self.contract_id = contract["id"]
         self.app.authorization = auth
 
-    lot2_create_tender_contract_document = snitch(lot2_create_tender_contract_document)
-    lot2_put_tender_contract_document = snitch(lot2_put_tender_contract_document)
-    lot2_patch_tender_contract_document = snitch(lot2_patch_tender_contract_document)
+    test_lot2_create_tender_contract_document = snitch(lot2_create_tender_contract_document)
+    test_lot2_put_tender_contract_document = snitch(lot2_put_tender_contract_document)
+    test_lot2_patch_tender_contract_document = snitch(lot2_patch_tender_contract_document)
+    test_lot2_create_tender_contract_document_by_supplier = snitch(lot2_create_tender_contract_document_by_supplier)
+    test_lot2_create_tender_contract_document_by_others = snitch(lot2_create_tender_contract_document_by_others)
+    test_lot2_put_tender_contract_document_by_supplier = snitch(lot2_put_tender_contract_document_by_supplier)
+    test_lot2_patch_tender_contract_document_by_supplier = snitch(lot2_patch_tender_contract_document_by_supplier)
 
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TenderContractResourceTest))
     suite.addTest(unittest.makeSuite(TenderContractDocumentResourceTest))
+    suite.addTest(unittest.makeSuite(TenderContractVATNotIncludedResourceTest))
+    suite.addTest(unittest.makeSuite(Tender2LotContractDocumentResourceTest))
     return suite
 
 

--- a/src/openprocurement/tender/belowthreshold/tests/contract_blanks.py
+++ b/src/openprocurement/tender/belowthreshold/tests/contract_blanks.py
@@ -939,6 +939,17 @@ def not_found(self):
 
 
 def create_tender_contract_document(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    self.assertEqual(response.json["data"]["status"], "pending")
+
+    doc = self.db.get(self.tender_id)
+    for i in doc.get("awards", []):
+        if "complaintPeriod" in i:
+            i["complaintPeriod"]["endDate"] = i["complaintPeriod"]["startDate"]
+    if 'value' in doc["contracts"][0] and doc["contracts"][0]["value"]["valueAddedTaxIncluded"]:
+        doc["contracts"][0]["value"]["amountNet"] = str(float(doc["contracts"][0]["value"]["amount"]) - 1)
+    self.db.save(doc)
+
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
         upload_files=[("file", "name.doc", "content")],
@@ -961,6 +972,32 @@ def create_tender_contract_document(self):
     self.assertEqual(response.content_type, "application/json")
     self.assertEqual(doc_id, response.json["data"][0]["id"])
     self.assertEqual("name.doc", response.json["data"][0]["title"])
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        upload_files=[("file", "contract.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"],
+                     [{u'description': u"Tender onwer can't add document in current contract status",
+                       u'location': u'body',
+                       u'name': u'data'}])
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending")
+
 
     response = self.app.get(
         "/tenders/{}/contracts/{}/documents/{}?download=some_id".format(self.tender_id, self.contract_id, doc_id),
@@ -1017,6 +1054,187 @@ def create_tender_contract_document(self):
     )
 
 
+def create_tender_contract_document_by_supplier(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+    doc = self.db.get(self.tender_id)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id=='{}'].owner_token".format(bid_id), doc)[0]
+
+    for bid in doc.get("bids", []):
+        if bid["id"] == bid_id and bid["status"] == "pending":
+            bid["status"] = "active"
+    for i in doc.get("awards", []):
+        if 'complaintPeriod' in i:
+            i["complaintPeriod"]["endDate"] = i["complaintPeriod"]["startDate"]
+    if 'value' in doc['contracts'][0] and doc['contracts'][0]['value']['valueAddedTaxIncluded']:
+        doc['contracts'][0]['value']['amountNet'] = str(float(doc['contracts'][0]['value']['amount']) - 1)
+    self.db.save(doc)
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"],
+                     [{u'description': u"Supplier can't add document in current contract status",
+                       u'location': u'body',
+                       u'name': u'data'}])
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+    )
+    self.assertEqual(response.status, "201 Created")
+    self.assertEqual(response.content_type, "application/json")
+    doc_id = response.json["data"]["id"]
+    self.assertIn(doc_id, response.headers["Location"])
+    self.assertEqual("name.doc", response.json["data"]["title"])
+    key = response.json["data"]["url"].split("?")[-1]
+
+    response = self.app.get("/tenders/{}/contracts/{}/documents".format(self.tender_id, self.contract_id))
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"][0]["id"])
+    self.assertEqual("name.doc", response.json["data"][0]["title"])
+
+    response = self.app.get("/tenders/{}/contracts/{}/documents?all=true".format(self.tender_id, self.contract_id))
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"][0]["id"])
+    self.assertEqual("name.doc", response.json["data"][0]["title"])
+
+    response = self.app.get(
+        "/tenders/{}/contracts/{}/documents/{}?download=some_id".format(self.tender_id, self.contract_id, doc_id),
+        status=404,
+    )
+    self.assertEqual(response.status, "404 Not Found")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["status"], "error")
+    self.assertEqual(
+        response.json["errors"], [{u"description": u"Not Found", u"location": u"url", u"name": u"download"}]
+    )
+
+    response = self.app.get(
+        "/tenders/{}/contracts/{}/documents/{}?{}".format(self.tender_id, self.contract_id, doc_id, key)
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/msword")
+    self.assertEqual(response.content_length, 7)
+    self.assertEqual(response.body, "content")
+
+    response = self.app.get("/tenders/{}/contracts/{}/documents/{}".format(self.tender_id, self.contract_id, doc_id))
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"]["id"])
+    self.assertEqual("name.doc", response.json["data"]["title"])
+
+    tender = self.db.get(self.tender_id)
+    tender["contracts"][-1]["status"] = "cancelled"
+    self.db.save(tender)
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't add document in current contract status")
+
+    self.set_status("{}".format(self.forbidden_contract_document_modification_actions_status))
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't add document in current contract status")
+
+
+def create_tender_contract_document_by_others(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+
+    doc = self.db.get(self.tender_id)
+    for i in doc.get("awards", []):
+        if 'complaintPeriod' in i:
+            i["complaintPeriod"]["endDate"] = i["complaintPeriod"]["startDate"]
+    if 'value' in doc['contracts'][0] and doc['contracts'][0]['value']['valueAddedTaxIncluded']:
+        doc['contracts'][0]['value']['amountNet'] = str(float(doc['contracts'][0]['value']['amount']) - 1)
+    self.db.save(doc)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id!='{}'].owner_token".format(bid_id), doc)[0]
+
+    # Bid owner
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"],
+                     [{u'description': u'Forbidden', u'location': u'url', u'name': u'permission'}])
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    # Bid onwer
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"], [{"location": "url", "name": "permission", "description": "Forbidden"}])
+
+    tender = self.db.get(self.tender_id)
+    tender["contracts"][-1]["status"] = "cancelled"
+    self.db.save(tender)
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"], "Forbidden")
+
+    self.set_status("{}".format(self.forbidden_contract_document_modification_actions_status))
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"], "Forbidden")
+
+
 def put_tender_contract_document(self):
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
@@ -1038,6 +1256,31 @@ def put_tender_contract_document(self):
     self.assertEqual(response.content_type, "application/json")
     self.assertEqual(response.json["status"], "error")
     self.assertEqual(response.json["errors"], [{u"description": u"Not Found", u"location": u"body", u"name": u"file"}])
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, self.tender_token
+        ),
+        upload_files=[("file", "name.doc", "content2")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Tender onwer can't update document in current contract status")
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending")
 
     response = self.app.put(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -1118,6 +1361,183 @@ def put_tender_contract_document(self):
     )
 
 
+def put_tender_contract_document_by_supplier(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+    doc = self.db.get(self.tender_id)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id=='{}'].owner_token".format(bid_id), doc)[0]
+
+    for bid in doc.get("bids", []):
+        if bid["id"] == bid_id and bid["status"] == "pending":
+            bid["status"] = "active"
+    for i in doc.get("awards", []):
+        if 'complaintPeriod' in i:
+            i["complaintPeriod"]["endDate"] = i["complaintPeriod"]["startDate"]
+    if 'value' in doc['contracts'][0] and doc['contracts'][0]['value']['valueAddedTaxIncluded']:
+        doc['contracts'][0]['value']['amountNet'] = str(float(doc['contracts'][0]['value']['amount']) - 1)
+    self.db.save(doc)
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't add document in current contract status")
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+    )
+    self.assertEqual(response.status, "201 Created")
+    self.assertEqual(response.content_type, "application/json")
+    doc_id = response.json["data"]["id"]
+    self.assertIn(doc_id, response.headers["Location"])
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        status=404,
+        upload_files=[("invalid_name", "name.doc", "content")],
+    )
+    self.assertEqual(response.status, "404 Not Found")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["status"], "error")
+    self.assertEqual(response.json["errors"], [{u"description": u"Not Found", u"location": u"body", u"name": u"file"}])
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        upload_files=[("file", "name.doc", "content2")],
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"]["id"])
+    key = response.json["data"]["url"].split("?")[-1]
+
+    response = self.app.get(
+        "/tenders/{}/contracts/{}/documents/{}?{}".format(self.tender_id, self.contract_id, doc_id, key)
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/msword")
+    self.assertEqual(response.content_length, 8)
+    self.assertEqual(response.body, "content2")
+
+    response = self.app.get("/tenders/{}/contracts/{}/documents/{}".format(self.tender_id, self.contract_id, doc_id))
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"]["id"])
+    self.assertEqual("name.doc", response.json["data"]["title"])
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        "content3",
+        content_type="application/msword",
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"]["id"])
+    key = response.json["data"]["url"].split("?")[-1]
+
+    response = self.app.get(
+        "/tenders/{}/contracts/{}/documents/{}?{}".format(self.tender_id, self.contract_id, doc_id, key)
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/msword")
+    self.assertEqual(response.content_length, 8)
+    self.assertEqual(response.body, "content3")
+
+    tender = self.db.get(self.tender_id)
+    tender["contracts"][-1]["status"] = "cancelled"
+    self.db.save(tender)
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        upload_files=[("file", "name.doc", "content3")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't update document in current contract status")
+
+    self.set_status("{}".format(self.forbidden_contract_document_modification_actions_status))
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        upload_files=[("file", "name.doc", "content3")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't update document in current contract status")
+
+
+def put_tender_contract_document_by_others(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+    doc = self.db.get(self.tender_id)
+    for i in doc.get("awards", []):
+        if 'complaintPeriod' in i:
+            i["complaintPeriod"]["endDate"] = i["complaintPeriod"]["startDate"]
+    if 'value' in doc['contracts'][0] and doc['contracts'][0]['value']['valueAddedTaxIncluded']:
+        doc['contracts'][0]['value']['amountNet'] = str(float(doc['contracts'][0]['value']['amount']) - 1)
+    self.db.save(doc)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id!='{}'].owner_token".format(bid_id), doc)[0]
+
+    # Bid onwer
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"],
+                     [{u'description': u'Forbidden', u'location': u'url', u'name': u'permission'}])
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    # Bid owner
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"],
+                     [{u'description': u'Forbidden', u'location': u'url', u'name': u'permission'}])
+
+
 def patch_tender_contract_document(self):
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
@@ -1127,6 +1547,31 @@ def patch_tender_contract_document(self):
     self.assertEqual(response.content_type, "application/json")
     doc_id = response.json["data"]["id"]
     self.assertIn(doc_id, response.headers["Location"])
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, self.tender_token
+        ),
+        {"data": {"description": "document description"}},
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Tender onwer can't update document in current contract status")
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending")
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -1178,12 +1623,187 @@ def patch_tender_contract_document(self):
     )
 
 
+def patch_tender_contract_document_by_supplier(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+    doc = self.db.get(self.tender_id)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id=='{}'].owner_token".format(bid_id), doc)[0]
+
+    for bid in doc.get("bids", []):
+        if bid["id"] == bid_id and bid["status"] == "pending":
+            bid["status"] = "active"
+    for i in doc.get("awards", []):
+        if 'complaintPeriod' in i:
+            i["complaintPeriod"]["endDate"] = i["complaintPeriod"]["startDate"]
+    if 'value' in doc['contracts'][0] and doc['contracts'][0]['value']['valueAddedTaxIncluded']:
+        doc['contracts'][0]['value']['amountNet'] = str(float(doc['contracts'][0]['value']['amount']) - 1)
+    self.db.save(doc)
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't add document in current contract status")
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+    )
+    self.assertEqual(response.status, "201 Created")
+    self.assertEqual(response.content_type, "application/json")
+    doc_id = response.json["data"]["id"]
+    self.assertIn(doc_id, response.headers["Location"])
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        {"data": {"description": "document description"}},
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"]["id"])
+
+    response = self.app.get("/tenders/{}/contracts/{}/documents/{}".format(self.tender_id, self.contract_id, doc_id))
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"]["id"])
+    self.assertEqual("document description", response.json["data"]["description"])
+
+    tender = self.db.get(self.tender_id)
+    tender["contracts"][-1]["status"] = "cancelled"
+    self.db.save(tender)
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, self.tender_token
+        ),
+        {"data": {"description": "document description"}},
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"], "Can't update document in current contract status")
+
+    self.set_status("{}".format(self.forbidden_contract_document_modification_actions_status))
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, self.tender_token
+        ),
+        {"data": {"description": "document description"}},
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(
+        response.json["errors"][0]["description"],
+        "Can't update document in current ({}) tender status".format(
+            self.forbidden_contract_document_modification_actions_status
+        ),
+    )
+
+
 # Tender2LotContractDocumentResourceTest
 
 
 def lot2_create_tender_contract_document(self):
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Tender onwer can't add document in current contract status")
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending")
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        upload_files=[("file", "name.doc", "content")],
+    )
+    self.assertEqual(response.status, "201 Created")
+    self.assertEqual(response.content_type, "application/json")
+    doc_id = response.json["data"]["id"]
+    self.assertIn(doc_id, response.headers["Location"])
+    self.assertEqual("name.doc", response.json["data"]["title"])
+    key = response.json["data"]["url"].split("?")[-1]
+
+    cancellation = dict(**test_cancellation)
+    cancellation.update({
+        "status": "active",
+        "cancellationOf": "lot",
+        "relatedLot": self.initial_lots[0]["id"],
+    })
+
+    response = self.app.post_json(
+        "/tenders/{}/cancellations?acc_token={}".format(self.tender_id, self.tender_token), {"data": cancellation},
+    )
+
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"], "Can add document only in active lot status")
+
+
+def lot2_create_tender_contract_document_by_supplier(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+    doc = self.db.get(self.tender_id)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id=='{}'].owner_token".format(bid_id), doc)[0]
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't add document in current contract status")
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
         upload_files=[("file", "name.doc", "content")],
     )
     self.assertEqual(response.status, "201 Created")
@@ -1204,14 +1824,52 @@ def lot2_create_tender_contract_document(self):
         {"data": cancellation},
     )
 
+    # Supplier
     response = self.app.post(
-        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
         upload_files=[("file", "name.doc", "content")],
         status=403,
     )
     self.assertEqual(response.status, "403 Forbidden")
     self.assertEqual(response.content_type, "application/json")
     self.assertEqual(response.json["errors"][0]["description"], "Can add document only in active lot status")
+
+
+def lot2_create_tender_contract_document_by_others(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+    doc = self.db.get(self.tender_id)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id!='{}'].owner_token".format(bid_id), doc)[0]
+
+    # Bid owner
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"],
+                     [{u'description': u'Forbidden', u'location': u'url', u'name': u'permission'}])
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    # Bid owner
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"],
+                     [{u'description': u'Forbidden', u'location': u'url', u'name': u'permission'}])
 
 
 def lot2_put_tender_contract_document(self):
@@ -1235,6 +1893,31 @@ def lot2_put_tender_contract_document(self):
     self.assertEqual(response.content_type, "application/json")
     self.assertEqual(response.json["status"], "error")
     self.assertEqual(response.json["errors"], [{u"description": u"Not Found", u"location": u"body", u"name": u"file"}])
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, self.tender_token
+        ),
+        upload_files=[("file", "name.doc", "content2")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Tender onwer can't update document in current contract status")
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending")
 
     response = self.app.put(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -1270,6 +1953,90 @@ def lot2_put_tender_contract_document(self):
     self.assertEqual(response.json["errors"][0]["description"], "Can update document only in active lot status")
 
 
+def lot2_put_tender_contract_document_by_supplier(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+    doc = self.db.get(self.tender_id)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id=='{}'].owner_token".format(bid_id), doc)[0]
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't add document in current contract status")
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+    )
+    self.assertEqual(response.status, "201 Created")
+    self.assertEqual(response.content_type, "application/json")
+    doc_id = response.json["data"]["id"]
+    self.assertIn(doc_id, response.headers["Location"])
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        status=404,
+        upload_files=[("invalid_name", "name.doc", "content")],
+    )
+    self.assertEqual(response.status, "404 Not Found")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["status"], "error")
+    self.assertEqual(response.json["errors"], [{u"description": u"Not Found", u"location": u"body", u"name": u"file"}])
+
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        upload_files=[("file", "name.doc", "content2")],
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"]["id"])
+    key = response.json["data"]["url"].split("?")[-1]
+
+    # Tender owner
+    cancellation = dict(**test_cancellation)
+    cancellation.update({
+        "status": "active",
+        "cancellationOf": "lot",
+        "relatedLot": self.initial_lots[0]["id"],
+    })
+    response = self.app.post_json(
+        "/tenders/{}/cancellations?acc_token={}".format(self.tender_id, self.tender_token),
+        {"data": cancellation},
+    )
+
+    # Supplier
+    response = self.app.put(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        upload_files=[("file", "name.doc", "content3")],
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"], "Can update document only in active lot status")
+
+
 def lot2_patch_tender_contract_document(self):
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
@@ -1281,11 +2048,37 @@ def lot2_patch_tender_contract_document(self):
     self.assertIn(doc_id, response.headers["Location"])
 
     response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, self.tender_token
+        ),
+        {"data": {"description": "document description"}},
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Tender onwer can't update document in current contract status")
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending")
+
+    response = self.app.patch_json(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
             self.tender_id, self.contract_id, doc_id, self.tender_token
         ),
         {"data": {"description": "document description"}},
     )
+
     self.assertEqual(response.status, "200 OK")
     self.assertEqual(response.content_type, "application/json")
     self.assertEqual(doc_id, response.json["data"]["id"])
@@ -1311,3 +2104,85 @@ def lot2_patch_tender_contract_document(self):
     self.assertEqual(response.status, "403 Forbidden")
     self.assertEqual(response.content_type, "application/json")
     self.assertEqual(response.json["errors"][0]["description"], "Can update document only in active lot status")
+
+
+def lot2_patch_tender_contract_document_by_supplier(self):
+    response = self.app.get("/tenders/{}/contracts/{}".format(self.tender_id, self.contract_id))
+    contract = response.json["data"]
+    self.assertEqual(response.json["data"]["status"], "pending")
+    doc = self.db.get(self.tender_id)
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract["awardID"]), doc)[0]
+    bid_token = jmespath.search("bids[?id=='{}'].owner_token".format(bid_id), doc)[0]
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending.winnerSigning"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+
+    # Supplier
+    response = self.app.post(
+        "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
+        upload_files=[("file", "name.doc", "content")],
+    )
+    self.assertEqual(response.status, "201 Created")
+    self.assertEqual(response.content_type, "application/json")
+    doc_id = response.json["data"]["id"]
+    self.assertIn(doc_id, response.headers["Location"])
+
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        {"data": {"description": "document description"}},
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(doc_id, response.json["data"]["id"])
+
+    # Tender owner
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
+        {"data": {"status": "pending"}}
+    )
+    self.assertEqual(response.status, "200 OK")
+    self.assertEqual(response.json["data"]["status"], "pending")
+
+    # Supplier
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        {"data": {"description": "document description"}},
+        status=403
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't update document in current contract status")
+
+    # Tender owner
+    cancellation = dict(**test_cancellation)
+    cancellation.update({
+        "status": "active",
+        "cancellationOf": "lot",
+        "relatedLot": self.initial_lots[0]["id"],
+    })
+
+    response = self.app.post_json(
+        "/tenders/{}/cancellations?acc_token={}".format(self.tender_id, self.tender_token), {"data": cancellation},
+    )
+
+    # Supplier
+    response = self.app.patch_json(
+        "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
+            self.tender_id, self.contract_id, doc_id, bid_token
+        ),
+        {"data": {"description": "new document description"}},
+        status=403,
+    )
+    self.assertEqual(response.status, "403 Forbidden")
+    self.assertEqual(response.content_type, "application/json")
+    self.assertEqual(response.json["errors"][0]["description"],
+                     "Supplier can't update document in current contract status")

--- a/src/openprocurement/tender/belowthreshold/tests/contract_blanks.py
+++ b/src/openprocurement/tender/belowthreshold/tests/contract_blanks.py
@@ -1765,6 +1765,9 @@ def lot2_create_tender_contract_document(self):
         "/tenders/{}/cancellations?acc_token={}".format(self.tender_id, self.tender_token), {"data": cancellation},
     )
 
+    if RELEASE_2020_04_19 < get_now():
+        activate_cancellation_after_2020_04_19(self, response.json['data']['id'])
+
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
         upload_files=[("file", "name.doc", "content")],
@@ -1823,6 +1826,9 @@ def lot2_create_tender_contract_document_by_supplier(self):
         "/tenders/{}/cancellations?acc_token={}".format(self.tender_id, self.tender_token),
         {"data": cancellation},
     )
+
+    if RELEASE_2020_04_19 < get_now():
+        activate_cancellation_after_2020_04_19(self, response.json['data']['id'])
 
     # Supplier
     response = self.app.post(
@@ -1941,6 +1947,9 @@ def lot2_put_tender_contract_document(self):
         {"data": cancellation},
     )
 
+    if RELEASE_2020_04_19 < get_now():
+        activate_cancellation_after_2020_04_19(self, response.json['data']['id'])
+
     response = self.app.put(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
             self.tender_id, self.contract_id, doc_id, self.tender_token
@@ -2024,6 +2033,9 @@ def lot2_put_tender_contract_document_by_supplier(self):
         {"data": cancellation},
     )
 
+    if RELEASE_2020_04_19 < get_now():
+        activate_cancellation_after_2020_04_19(self, response.json['data']['id'])
+
     # Supplier
     response = self.app.put(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -2093,6 +2105,9 @@ def lot2_patch_tender_contract_document(self):
         "/tenders/{}/cancellations?acc_token={}".format(self.tender_id, self.tender_token),
         {"data": cancellation},
     )
+
+    if RELEASE_2020_04_19 < get_now():
+        activate_cancellation_after_2020_04_19(self, response.json['data']['id'])
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(

--- a/src/openprocurement/tender/belowthreshold/tests/contract_blanks.py
+++ b/src/openprocurement/tender/belowthreshold/tests/contract_blanks.py
@@ -561,10 +561,10 @@ def patch_tender_contract_status_by_owner(self):
     self.app.authorization = ("Basic", ("broker", ""))
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}},
+        {"data": {"status": "pending.winner-signing"}},
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, contract_id, self.tender_token),
@@ -605,7 +605,7 @@ def patch_tender_contract_status_by_supplier(self):
     self.app.authorization = ("Basic", ("broker", ""))
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, contract_id, bid_token),
-        {"data": {"status": "pending.winnerSigning"}},
+        {"data": {"status": "pending.winner-signing"}},
         status=403
     )
     self.assertEqual(response.status, "403 Forbidden")
@@ -628,10 +628,10 @@ def patch_tender_contract_status_by_supplier(self):
     # Tender onwer
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}},
+        {"data": {"status": "pending.winner-signing"}},
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
 
     # Supplier
@@ -685,7 +685,7 @@ def patch_tender_contract_status_by_others(self):
     self.app.authorization = ("Basic", ("broker", ""))
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, contract_id, bid_token),
-        {"data": {"status": "pending.winnerSigning"}},
+        {"data": {"status": "pending.winner-signing"}},
         status=403
     )
     self.assertEqual(response.status, "403 Forbidden")
@@ -694,10 +694,10 @@ def patch_tender_contract_status_by_others(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, contract_id, bid_token),
@@ -975,10 +975,10 @@ def create_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
@@ -1087,10 +1087,10 @@ def create_tender_contract_document_by_supplier(self):
     # Tender owner
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     # Supplier
     response = self.app.post(
@@ -1196,10 +1196,10 @@ def create_tender_contract_document_by_others(self):
     # Tender owner
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     # Bid onwer
     response = self.app.post(
@@ -1259,10 +1259,10 @@ def put_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.put(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -1392,10 +1392,10 @@ def put_tender_contract_document_by_supplier(self):
     # Tender owner
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     # Supplier
     response = self.app.post(
@@ -1522,10 +1522,10 @@ def put_tender_contract_document_by_others(self):
     # Tender owner
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     # Bid owner
     response = self.app.post(
@@ -1550,10 +1550,10 @@ def patch_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -1652,10 +1652,10 @@ def patch_tender_contract_document_by_supplier(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, bid_token),
@@ -1722,10 +1722,10 @@ def patch_tender_contract_document_by_supplier(self):
 def lot2_create_tender_contract_document(self):
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
@@ -1796,10 +1796,10 @@ def lot2_create_tender_contract_document_by_supplier(self):
     # Tender owner
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     # Supplier
     response = self.app.post(
@@ -1856,10 +1856,10 @@ def lot2_create_tender_contract_document_by_others(self):
     # Tender owner
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     # Bid owner
     response = self.app.post(
@@ -1896,10 +1896,10 @@ def lot2_put_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.put(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -1974,10 +1974,10 @@ def lot2_put_tender_contract_document_by_supplier(self):
     # Tender owner
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     # Supplier
     response = self.app.post(
@@ -2049,10 +2049,10 @@ def lot2_patch_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -2117,10 +2117,10 @@ def lot2_patch_tender_contract_document_by_supplier(self):
     # Tender owner
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     # Supplier
     response = self.app.post(

--- a/src/openprocurement/tender/belowthreshold/views/contract.py
+++ b/src/openprocurement/tender/belowthreshold/views/contract.py
@@ -63,7 +63,7 @@ class TenderAwardContractResource(APIResource):
 
     @json_view(
         content_type="application/json",
-        permission="edit_tender",
+        permission="edit_contract",
         validators=(
             validate_patch_contract_data,
             validate_contract_operation_not_in_allowed_status,

--- a/src/openprocurement/tender/belowthreshold/views/contract.py
+++ b/src/openprocurement/tender/belowthreshold/views/contract.py
@@ -11,6 +11,7 @@ from openprocurement.tender.core.validation import (
     validate_update_contract_value_with_award,
     validate_update_contract_value_amount,
     validate_update_contract_value_net_required,
+    validate_update_contract_status_by_supplier,
 )
 from openprocurement.tender.belowthreshold.utils import check_tender_status
 
@@ -68,6 +69,7 @@ class TenderAwardContractResource(APIResource):
             validate_patch_contract_data,
             validate_contract_operation_not_in_allowed_status,
             validate_update_contract_only_for_active_lots,
+            validate_update_contract_status_by_supplier,
             validate_update_contract_value,
             validate_contract_signing,
             validate_update_contract_value_net_required,
@@ -80,9 +82,9 @@ class TenderAwardContractResource(APIResource):
         """
         contract_status = self.request.context.status
         apply_patch(self.request, save=False, src=self.request.context.serialize())
-        if contract_status != self.request.context.status and (
-            contract_status != "pending" or self.request.context.status != "active"
-        ):
+        if contract_status != self.request.context.status and \
+                (contract_status not in ("pending", "pending.winnerSigning",) or \
+                self.request.context.status not in ("active", "pending", "pending.winnerSigning",)):
             raise_operation_error(self.request, "Can't update contract status")
         if self.request.context.status == "active" and not self.request.context.dateSigned:
             self.request.context.dateSigned = get_now()

--- a/src/openprocurement/tender/belowthreshold/views/contract.py
+++ b/src/openprocurement/tender/belowthreshold/views/contract.py
@@ -83,8 +83,8 @@ class TenderAwardContractResource(APIResource):
         contract_status = self.request.context.status
         apply_patch(self.request, save=False, src=self.request.context.serialize())
         if contract_status != self.request.context.status and \
-                (contract_status not in ("pending", "pending.winnerSigning",) or \
-                self.request.context.status not in ("active", "pending", "pending.winnerSigning",)):
+                (contract_status not in ("pending", "pending.winner-signing",) or \
+                self.request.context.status not in ("active", "pending", "pending.winner-signing",)):
             raise_operation_error(self.request, "Can't update contract status")
         if self.request.context.status == "active" and not self.request.context.dateSigned:
             self.request.context.dateSigned = get_now()

--- a/src/openprocurement/tender/belowthreshold/views/contract_document.py
+++ b/src/openprocurement/tender/belowthreshold/views/contract_document.py
@@ -47,7 +47,7 @@ class TenderAwardContractDocumentResource(APIResource):
             ]
         ):
             raise_operation_error(self.request, "Can {} document only in active lot status".format(operation))
-        if self.request.validated["contract"].status not in ["pending", "pending.winnerSigning", "active"]:
+        if self.request.validated["contract"].status not in ["pending", "pending.winner-signing", "active"]:
             raise_operation_error(self.request, "Can't {} document in current contract status".format(operation))
         return True
 

--- a/src/openprocurement/tender/belowthreshold/views/contract_document.py
+++ b/src/openprocurement/tender/belowthreshold/views/contract_document.py
@@ -62,7 +62,7 @@ class TenderAwardContractDocumentResource(APIResource):
             )
         return {"data": collection_data}
 
-    @json_view(permission="edit_tender", validators=(validate_file_upload,))
+    @json_view(permission="upload_contract_documents", validators=(validate_file_upload,))
     def collection_post(self):
         """Tender Contract Document Upload
         """
@@ -96,7 +96,7 @@ class TenderAwardContractDocumentResource(APIResource):
         ]
         return {"data": document_data}
 
-    @json_view(validators=(validate_file_update,), permission="edit_tender")
+    @json_view(validators=(validate_file_update,), permission="upload_contract_documents")
     def put(self):
         """Tender Contract Document Update"""
         if not self.validate_contract_document("update"):
@@ -110,7 +110,9 @@ class TenderAwardContractDocumentResource(APIResource):
             )
             return {"data": document.serialize("view")}
 
-    @json_view(content_type="application/json", validators=(validate_patch_document_data,), permission="edit_tender")
+    @json_view(content_type="application/json",
+               validators=(validate_patch_document_data,),
+               permission="upload_contract_documents")
     def patch(self):
         """Tender Contract Document Update"""
         if not self.validate_contract_document("update"):

--- a/src/openprocurement/tender/cfaselectionua/models/submodels/Contract.csv
+++ b/src/openprocurement/tender/cfaselectionua/models/submodels/Contract.csv
@@ -1,5 +1,7 @@
 rolename,status,value,documents,description,title,items,suppliers,contractNumber,title_en,period,description_en,dateSigned,title_ru,date,awardID,description_ru,id,__parent__,contractID
-edit,1,1,,1,1,,,1,1,1,1,1,1,,,1,,1,
+admins,1,1,,1,1,,,1,1,1,1,1,1,,,1,,1,
+edit_tender_owner,1,1,,1,1,,,1,1,1,1,1,1,,,1,,1,
+edit_contract_supplier,1,,,,,,,,,,,,,,,,,,
 default,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,,1
 create,,1,,1,1,1,1,1,1,1,1,,1,,1,1,,1,1
 embedded,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,,1

--- a/src/openprocurement/tender/cfaselectionua/models/submodels/contract.py
+++ b/src/openprocurement/tender/cfaselectionua/models/submodels/contract.py
@@ -17,6 +17,15 @@ class Contract(BaseContract):
     awardID = StringType(required=True)
     documents = ListType(ModelType(Document, required=True), default=list())
 
+    def get_role(self):
+        root = self.get_root()
+        request = root.request
+        if request.authenticated_role in ("tender_owner", "contract_supplier"):
+            role = "edit_{}".format(request.authenticated_role)
+        else:
+            role = request.authenticated_role
+        return role
+
     def __local_roles__(self):
         roles = {}
         roles.update(get_contract_supplier_roles(self))

--- a/src/openprocurement/tender/cfaselectionua/models/submodels/contract.py
+++ b/src/openprocurement/tender/cfaselectionua/models/submodels/contract.py
@@ -4,6 +4,7 @@ from schematics.exceptions import ValidationError
 from schematics.types.compound import ModelType
 from schematics.types import StringType
 from openprocurement.tender.core.models import ContractValue
+from openprocurement.tender.core.utils import get_contract_supplier_roles
 from openprocurement.api.utils import get_now
 from openprocurement.api.models import Model, ListType, Contract as BaseContract, Document
 
@@ -15,6 +16,11 @@ class Contract(BaseContract):
     value = ModelType(ContractValue)
     awardID = StringType(required=True)
     documents = ListType(ModelType(Document, required=True), default=list())
+
+    def __local_roles__(self):
+        roles = {}
+        roles.update(get_contract_supplier_roles(self))
+        return roles
 
     def validate_awardID(self, data, awardID):
         parent = data["__parent__"]

--- a/src/openprocurement/tender/cfaselectionua/models/submodels/contract.py
+++ b/src/openprocurement/tender/cfaselectionua/models/submodels/contract.py
@@ -4,7 +4,7 @@ from schematics.exceptions import ValidationError
 from schematics.types.compound import ModelType
 from schematics.types import StringType
 from openprocurement.tender.core.models import ContractValue
-from openprocurement.tender.core.utils import get_contract_supplier_roles
+from openprocurement.tender.core.utils import get_contract_supplier_roles, get_contract_supplier_permissions
 from openprocurement.api.utils import get_now
 from openprocurement.api.models import Model, ListType, Contract as BaseContract, Document
 
@@ -16,6 +16,9 @@ class Contract(BaseContract):
     value = ModelType(ContractValue)
     awardID = StringType(required=True)
     documents = ListType(ModelType(Document, required=True), default=list())
+
+    def __acl__(self):
+        return get_contract_supplier_permissions(self)
 
     def get_role(self):
         root = self.get_root()

--- a/src/openprocurement/tender/cfaselectionua/models/tender.py
+++ b/src/openprocurement/tender/cfaselectionua/models/tender.py
@@ -23,7 +23,6 @@ from openprocurement.tender.core.models import (
     Cancellation as BaseCancellation,
     validate_features_uniq,
 )
-from openprocurement.tender.core.utils import get_contract_supplier_permissions
 
 
 class Cancellation(BaseCancellation):
@@ -233,9 +232,6 @@ class CFASelectionUATender(BaseTender):
                 (Allow, "g:brokers", "create_cancellation_complaint")
             ]
         )
-        suppliers_permissions = get_contract_supplier_permissions(self)
-        if suppliers_permissions:
-            acl.extend(suppliers_permissions)
         self._acl_cancellation(acl)
         return acl
 

--- a/src/openprocurement/tender/cfaselectionua/models/tender.py
+++ b/src/openprocurement/tender/cfaselectionua/models/tender.py
@@ -23,6 +23,7 @@ from openprocurement.tender.core.models import (
     Cancellation as BaseCancellation,
     validate_features_uniq,
 )
+from openprocurement.tender.core.utils import get_contract_supplier_permissions
 
 
 class Cancellation(BaseCancellation):
@@ -225,11 +226,16 @@ class CFASelectionUATender(BaseTender):
         acl.extend(
             [
                 (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_complaint"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_contract"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "upload_contract_documents"),
                 (Allow, "g:agreement_selection", "edit_agreement_selection"),
                 (Allow, "g:agreement_selection", "edit_tender"),
                 (Allow, "g:brokers", "create_cancellation_complaint")
             ]
         )
+        suppliers_permissions = get_contract_supplier_permissions(self)
+        if suppliers_permissions:
+            acl.extend(suppliers_permissions)
         self._acl_cancellation(acl)
         return acl
 

--- a/src/openprocurement/tender/cfaselectionua/tests/contract.py
+++ b/src/openprocurement/tender/cfaselectionua/tests/contract.py
@@ -36,6 +36,15 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_status_by_owner,
     patch_tender_contract_status_by_others,
     patch_tender_contract_status_by_supplier,
+    create_tender_contract_document_by_supplier,
+    create_tender_contract_document_by_others,
+    put_tender_contract_document_by_supplier,
+    put_tender_contract_document_by_others,
+    patch_tender_contract_document_by_supplier,
+    lot2_create_tender_contract_document_by_supplier,
+    lot2_create_tender_contract_document_by_others,
+    lot2_put_tender_contract_document_by_supplier,
+    lot2_patch_tender_contract_document_by_supplier,
 )
 
 
@@ -135,6 +144,11 @@ class TenderContractDocumentResourceTest(TenderContentWebTest, TenderContractDoc
     initial_bids = test_bids
     initial_lots = test_lots
 
+    test_create_tender_contract_document_by_supplier = snitch(create_tender_contract_document_by_supplier)
+    test_create_tender_contract_document_by_others = snitch(create_tender_contract_document_by_others)
+    test_put_tender_contract_document_by_supplier = snitch(put_tender_contract_document_by_supplier)
+    test_put_tender_contract_document_by_others = snitch(put_tender_contract_document_by_others)
+    test_patch_tender_contract_document_by_supplier = snitch(patch_tender_contract_document_by_supplier)
 
 @unittest.skip("Skip multi-lots tests")
 class Tender2LotContractDocumentResourceTest(TenderContentWebTest):
@@ -181,6 +195,10 @@ class Tender2LotContractDocumentResourceTest(TenderContentWebTest):
     lot2_create_tender_contract_document = snitch(lot2_create_tender_contract_document)
     lot2_put_tender_contract_document = snitch(lot2_put_tender_contract_document)
     lot2_patch_tender_contract_document = snitch(lot2_patch_tender_contract_document)
+    test_lot2_create_tender_contract_document_by_supplier = snitch(lot2_create_tender_contract_document_by_supplier)
+    test_lot2_create_tender_contract_document_by_others = snitch(lot2_create_tender_contract_document_by_others)
+    test_lot2_put_tender_contract_document_by_supplier = snitch(lot2_put_tender_contract_document_by_supplier)
+    test_lot2_patch_tender_contract_document_by_supplier = snitch(lot2_patch_tender_contract_document_by_supplier)
 
 
 def suite():

--- a/src/openprocurement/tender/cfaselectionua/tests/contract.py
+++ b/src/openprocurement/tender/cfaselectionua/tests/contract.py
@@ -33,6 +33,9 @@ from openprocurement.tender.cfaselectionua.tests.contract_blanks import (
 from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_value_vat_not_included,
     patch_tender_contract_value,
+    patch_tender_contract_status_by_owner,
+    patch_tender_contract_status_by_others,
+    patch_tender_contract_status_by_supplier,
 )
 
 
@@ -58,6 +61,9 @@ class TenderContractResourceTest(TenderContentWebTest, TenderContractResourceTes
     test_create_tender_contract_in_complete_status = snitch(create_tender_contract_in_complete_status)
     test_patch_tender_contract = snitch(patch_tender_contract)
     test_patch_tender_contract_value = snitch(patch_tender_contract_value)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderContractVATNotIncludedResourceTest(TenderContentWebTest, TenderContractResourceTestMixin):
@@ -67,7 +73,11 @@ class TenderContractVATNotIncludedResourceTest(TenderContentWebTest, TenderContr
 
     def update_vat_fields(self, items):
         for item in items:
-            item["value"]["valueAddedTaxIncluded"] = False
+            if "lotValues" in item:
+                for lot_value in item["lotValues"]:
+                    lot_value["value"]["valueAddedTaxIncluded"] = False
+            else:
+                item["value"]["valueAddedTaxIncluded"] = False
 
     def generate_bids(self, status, start_end="start"):
         self.initial_bids = deepcopy(self.initial_bids)
@@ -81,6 +91,9 @@ class TenderContractVATNotIncludedResourceTest(TenderContentWebTest, TenderContr
         self.update_vat_fields(agreement["contracts"])
 
     test_patch_tender_contract_value_vat_not_included = snitch(patch_tender_contract_value_vat_not_included)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 @unittest.skip("Skip multi-lots tests")

--- a/src/openprocurement/tender/cfaselectionua/tests/contract_blanks.py
+++ b/src/openprocurement/tender/cfaselectionua/tests/contract_blanks.py
@@ -587,10 +587,10 @@ def create_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
@@ -718,10 +718,10 @@ def put_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.put(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -840,10 +840,10 @@ def patch_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -919,10 +919,10 @@ def patch_tender_contract_document(self):
 def lot2_create_tender_contract_document(self):
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.post(
         "/tenders/{}/contracts/{}/documents?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
@@ -995,10 +995,10 @@ def lot2_put_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.put(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(
@@ -1063,10 +1063,10 @@ def lot2_patch_tender_contract_document(self):
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}?acc_token={}".format(self.tender_id, self.contract_id, self.tender_token),
-        {"data": {"status": "pending.winnerSigning"}}
+        {"data": {"status": "pending.winner-signing"}}
     )
     self.assertEqual(response.status, "200 OK")
-    self.assertEqual(response.json["data"]["status"], "pending.winnerSigning")
+    self.assertEqual(response.json["data"]["status"], "pending.winner-signing")
 
     response = self.app.patch_json(
         "/tenders/{}/contracts/{}/documents/{}?acc_token={}".format(

--- a/src/openprocurement/tender/cfaselectionua/views/contract.py
+++ b/src/openprocurement/tender/cfaselectionua/views/contract.py
@@ -62,7 +62,7 @@ class TenderAwardContractResource(APIResource):
 
     @json_view(
         content_type="application/json",
-        permission="edit_tender",
+        permission="edit_contract",
         validators=(
             validate_patch_contract_data,
             validate_contract_operation_not_in_allowed_status,

--- a/src/openprocurement/tender/cfaselectionua/views/contract.py
+++ b/src/openprocurement/tender/cfaselectionua/views/contract.py
@@ -81,8 +81,8 @@ class TenderAwardContractResource(APIResource):
         contract_status = self.request.context.status
         apply_patch(self.request, save=False, src=self.request.context.serialize())
         if contract_status != self.request.context.status and \
-                (contract_status not in ("pending", "pending.winnerSigning",) or \
-                self.request.context.status not in ("active", "pending", "pending.winnerSigning",)):
+                (contract_status not in ("pending", "pending.winner-signing",) or \
+                self.request.context.status not in ("active", "pending", "pending.winner-signing",)):
             raise_operation_error(self.request, "Can't update contract status")
         if self.request.context.status == "active" and not self.request.context.dateSigned:
             self.request.context.dateSigned = get_now()

--- a/src/openprocurement/tender/cfaselectionua/views/contract.py
+++ b/src/openprocurement/tender/cfaselectionua/views/contract.py
@@ -10,6 +10,7 @@ from openprocurement.tender.core.validation import (
     validate_update_contract_value_with_award,
     validate_update_contract_value_amount,
     validate_update_contract_value_net_required,
+    validate_update_contract_status_by_supplier,
 )
 from openprocurement.tender.cfaselectionua.utils import check_tender_status
 
@@ -66,6 +67,7 @@ class TenderAwardContractResource(APIResource):
         validators=(
             validate_patch_contract_data,
             validate_contract_operation_not_in_allowed_status,
+            validate_update_contract_status_by_supplier,
             validate_update_contract_only_for_active_lots,
             validate_update_contract_value,
             validate_update_contract_value_net_required,
@@ -78,9 +80,9 @@ class TenderAwardContractResource(APIResource):
         """
         contract_status = self.request.context.status
         apply_patch(self.request, save=False, src=self.request.context.serialize())
-        if contract_status != self.request.context.status and (
-            contract_status != "pending" or self.request.context.status != "active"
-        ):
+        if contract_status != self.request.context.status and \
+                (contract_status not in ("pending", "pending.winnerSigning",) or \
+                self.request.context.status not in ("active", "pending", "pending.winnerSigning",)):
             raise_operation_error(self.request, "Can't update contract status")
         if self.request.context.status == "active" and not self.request.context.dateSigned:
             self.request.context.dateSigned = get_now()

--- a/src/openprocurement/tender/cfaselectionua/views/contract_document.py
+++ b/src/openprocurement/tender/cfaselectionua/views/contract_document.py
@@ -47,7 +47,7 @@ class TenderAwardContractDocumentResource(APIResource):
             ]
         ):
             raise_operation_error(self.request, "Can {} document only in active lot status".format(operation))
-        if self.request.validated["contract"].status not in ["pending", "pending.winnerSigning", "active"]:
+        if self.request.validated["contract"].status not in ["pending", "pending.winner-signing", "active"]:
             raise_operation_error(self.request, "Can't {} document in current contract status".format(operation))
         return True
 

--- a/src/openprocurement/tender/cfaselectionua/views/contract_document.py
+++ b/src/openprocurement/tender/cfaselectionua/views/contract_document.py
@@ -62,7 +62,7 @@ class TenderAwardContractDocumentResource(APIResource):
             )
         return {"data": collection_data}
 
-    @json_view(permission="edit_tender", validators=(validate_file_upload,))
+    @json_view(permission="upload_contract_documents", validators=(validate_file_upload,))
     def collection_post(self):
         """Tender Contract Document Upload
         """
@@ -96,7 +96,7 @@ class TenderAwardContractDocumentResource(APIResource):
         ]
         return {"data": document_data}
 
-    @json_view(validators=(validate_file_update,), permission="edit_tender")
+    @json_view(validators=(validate_file_update,), permission="upload_contract_documents")
     def put(self):
         """Tender Contract Document Update"""
         if not self.validate_contract_document("update"):
@@ -110,7 +110,9 @@ class TenderAwardContractDocumentResource(APIResource):
             )
             return {"data": document.serialize("view")}
 
-    @json_view(content_type="application/json", validators=(validate_patch_document_data,), permission="edit_tender")
+    @json_view(content_type="application/json",
+               validators=(validate_patch_document_data,),
+               permission="upload_contract_documents")
     def patch(self):
         """Tender Contract Document Update"""
         if not self.validate_contract_document("update"):

--- a/src/openprocurement/tender/competitivedialogue/models.py
+++ b/src/openprocurement/tender/competitivedialogue/models.py
@@ -33,7 +33,7 @@ from openprocurement.tender.core.models import (
     Lot as BaseLotUA,
     EUConfidentialDocument,
 )
-from openprocurement.tender.core.utils import calculate_tender_business_date
+from openprocurement.tender.core.utils import calculate_tender_business_date, get_contract_supplier_permissions
 from openprocurement.tender.openua.models import Item as BaseUAItem, Tender as BaseTenderUA
 from openprocurement.tender.openua.constants import TENDER_PERIOD as TENDERING_DURATION_UA
 from openprocurement.tender.openeu.models import (
@@ -377,6 +377,8 @@ def stage2__acl__(obj):
     acl = [
         (Allow, "{}_{}".format(obj.owner, obj.dialogue_token), "generate_credentials"),
         (Allow, "{}_{}".format(obj.owner, obj.owner_token), "edit_complaint"),
+        (Allow, "{}_{}".format(obj.owner, obj.owner_token), "edit_contract"),
+        (Allow, "{}_{}".format(obj.owner, obj.owner_token), "upload_contract_documents"),
         (Allow, "g:competitive_dialogue", "edit_tender"),
         (Allow, "g:competitive_dialogue", "edit_cancellation")
     ]
@@ -394,6 +396,10 @@ def stage2__acl__(obj):
             if i.status == "active"
         ]
     )
+
+    suppliers_permissions = get_contract_supplier_permissions(obj)
+    if suppliers_permissions:
+        acl.extend(suppliers_permissions)
     return acl
 
 

--- a/src/openprocurement/tender/competitivedialogue/models.py
+++ b/src/openprocurement/tender/competitivedialogue/models.py
@@ -33,7 +33,7 @@ from openprocurement.tender.core.models import (
     Lot as BaseLotUA,
     EUConfidentialDocument,
 )
-from openprocurement.tender.core.utils import calculate_tender_business_date, get_contract_supplier_permissions
+from openprocurement.tender.core.utils import calculate_tender_business_date
 from openprocurement.tender.openua.models import Item as BaseUAItem, Tender as BaseTenderUA
 from openprocurement.tender.openua.constants import TENDER_PERIOD as TENDERING_DURATION_UA
 from openprocurement.tender.openeu.models import (
@@ -397,9 +397,6 @@ def stage2__acl__(obj):
         ]
     )
 
-    suppliers_permissions = get_contract_supplier_permissions(obj)
-    if suppliers_permissions:
-        acl.extend(suppliers_permissions)
     return acl
 
 

--- a/src/openprocurement/tender/competitivedialogue/tests/stage2/contract.py
+++ b/src/openprocurement/tender/competitivedialogue/tests/stage2/contract.py
@@ -24,6 +24,11 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_status_by_owner,
     patch_tender_contract_status_by_others,
     patch_tender_contract_status_by_supplier,
+    create_tender_contract_document_by_supplier,
+    create_tender_contract_document_by_others,
+    put_tender_contract_document_by_supplier,
+    put_tender_contract_document_by_others,
+    patch_tender_contract_document_by_supplier,
 )
 from openprocurement.tender.openua.tests.contract_blanks import (
     # TenderStage2EU(UA)ContractResourceTest
@@ -116,6 +121,12 @@ class TenderStage2EUContractDocumentResourceTest(
         contract = response.json["data"]
         self.contract_id = contract["id"]
         self.app.authorization = ("Basic", ("broker", ""))
+
+    test_create_tender_contract_document_by_supplier = snitch(create_tender_contract_document_by_supplier)
+    test_create_tender_contract_document_by_others = snitch(create_tender_contract_document_by_others)
+    test_put_tender_contract_document_by_supplier = snitch(put_tender_contract_document_by_supplier)
+    test_put_tender_contract_document_by_others = snitch(put_tender_contract_document_by_others)
+    test_patch_tender_contract_document_by_supplier = snitch(patch_tender_contract_document_by_supplier)
 
 
 class TenderStage2UAContractResourceTest(BaseCompetitiveDialogUAStage2ContentWebTest):
@@ -226,6 +237,12 @@ class TenderStage2UAContractDocumentResourceTest(
         contract = response.json["data"]
         self.contract_id = contract["id"]
         self.app.authorization = auth
+
+    test_create_tender_contract_document_by_supplier = snitch(create_tender_contract_document_by_supplier)
+    test_create_tender_contract_document_by_others = snitch(create_tender_contract_document_by_others)
+    test_put_tender_contract_document_by_supplier = snitch(put_tender_contract_document_by_supplier)
+    test_put_tender_contract_document_by_others = snitch(put_tender_contract_document_by_others)
+    test_patch_tender_contract_document_by_supplier = snitch(patch_tender_contract_document_by_supplier)
 
 
 def suite():

--- a/src/openprocurement/tender/competitivedialogue/tests/stage2/contract.py
+++ b/src/openprocurement/tender/competitivedialogue/tests/stage2/contract.py
@@ -21,6 +21,9 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     create_tender_contract,
     patch_tender_contract_value_vat_not_included,
     patch_tender_contract_value,
+    patch_tender_contract_status_by_owner,
+    patch_tender_contract_status_by_others,
+    patch_tender_contract_status_by_supplier,
 )
 from openprocurement.tender.openua.tests.contract_blanks import (
     # TenderStage2EU(UA)ContractResourceTest
@@ -78,6 +81,9 @@ class TenderStage2EUContractResourceTest(BaseCompetitiveDialogEUStage2ContentWeb
     test_create_tender_contract = snitch(create_tender_contract)
     test_patch_tender_contract_datesigned = snitch(patch_tender_contract_datesigned)
     test_patch_tender_contract = snitch(patch_tender_contract_eu)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderStage2EUContractDocumentResourceTest(
@@ -147,6 +153,9 @@ class TenderStage2UAContractResourceTest(BaseCompetitiveDialogUAStage2ContentWeb
     test_patch_tender_contract_datesigned = snitch(patch_tender_contract_datesigned)
     test_patch_tender_contract = snitch(patch_tender_contract)
     test_patch_tender_contract_value = snitch(patch_tender_contract_value)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderContractVATNotIncludedResourceTest(BaseCompetitiveDialogUAStage2ContentWebTest):
@@ -183,6 +192,9 @@ class TenderContractVATNotIncludedResourceTest(BaseCompetitiveDialogUAStage2Cont
         self.create_award()
 
     test_patch_tender_contract_value_vat_not_included = snitch(patch_tender_contract_value_vat_not_included)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderStage2UAContractDocumentResourceTest(

--- a/src/openprocurement/tender/core/models.py
+++ b/src/openprocurement/tender/core/models.py
@@ -386,6 +386,9 @@ class Contract(BaseContract):
     awardID = StringType(required=True)
     documents = ListType(ModelType(Document, required=True), default=list())
 
+    def __acl__(self):
+        return get_contract_supplier_permissions(self)
+
     def get_role(self):
         root = self.get_root()
         request = root.request
@@ -1420,9 +1423,6 @@ class Tender(BaseTender):
 
     def __acl__(self):
         acl = [(Allow, "{}_{}".format(i.owner, i.owner_token), "create_award_complaint") for i in self.bids]
-        suppliers_permissions = get_contract_supplier_permissions(self)
-        if suppliers_permissions:
-            acl.extend(suppliers_permissions)
         acl.extend(
             [
                 (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_complaint"),

--- a/src/openprocurement/tender/core/models.py
+++ b/src/openprocurement/tender/core/models.py
@@ -54,7 +54,7 @@ from openprocurement.tender.core.constants import (
 )
 from openprocurement.tender.core.utils import (
     calc_auction_end_time, rounding_shouldStartAfter,
-    restrict_value_to_bounds, round_up_to_ten,
+    restrict_value_to_bounds, round_up_to_ten, get_contract_supplier_roles,
 )
 from openprocurement.tender.core.validation import (
     validate_lotvalue_value,
@@ -382,6 +382,11 @@ class Contract(BaseContract):
     value = ModelType(ContractValue)
     awardID = StringType(required=True)
     documents = ListType(ModelType(Document, required=True), default=list())
+
+    def __local_roles__(self):
+        roles = {}
+        roles.update(get_contract_supplier_roles(self))
+        return roles
 
     def validate_awardID(self, data, awardID):
         parent = data["__parent__"]
@@ -793,7 +798,7 @@ class Complaint(Model):
         parent = data["__parent__"]
         if relatedLot and isinstance(parent, Model):
             validate_relatedlot(get_tender(parent), relatedLot)
-            
+
     def get_related_lot_obj(self, tender):
         lot_id = (
             self.get("relatedLot")  # tender lot

--- a/src/openprocurement/tender/core/models.py
+++ b/src/openprocurement/tender/core/models.py
@@ -54,7 +54,8 @@ from openprocurement.tender.core.constants import (
 )
 from openprocurement.tender.core.utils import (
     calc_auction_end_time, rounding_shouldStartAfter,
-    restrict_value_to_bounds, round_up_to_ten, get_contract_supplier_roles,
+    restrict_value_to_bounds, round_up_to_ten,
+    get_contract_supplier_roles, get_contract_supplier_permissions,
 )
 from openprocurement.tender.core.validation import (
     validate_lotvalue_value,
@@ -1408,9 +1409,14 @@ class Tender(BaseTender):
 
     def __acl__(self):
         acl = [(Allow, "{}_{}".format(i.owner, i.owner_token), "create_award_complaint") for i in self.bids]
+        suppliers_permissions = get_contract_supplier_permissions(self)
+        if suppliers_permissions:
+            acl.extend(suppliers_permissions)
         acl.extend(
             [
                 (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_complaint"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_contract"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "upload_contract_documents"),
             ]
         )
         self._acl_cancellation_complaint(acl)

--- a/src/openprocurement/tender/core/models.py
+++ b/src/openprocurement/tender/core/models.py
@@ -375,7 +375,9 @@ class Contract(BaseContract):
     class Options:
         roles = {
             "create": blacklist("id", "status", "date", "documents", "dateSigned"),
-            "edit": blacklist("id", "documents", "date", "awardID", "suppliers", "items", "contractID"),
+            "admins": blacklist("id", "documents", "date", "awardID", "suppliers", "items", "contractID"),
+            "edit_tender_owner": blacklist("id", "documents", "date", "awardID", "suppliers", "items", "contractID"),
+            "edit_contract_supplier": whitelist("status"),
             "embedded": schematics_embedded_role,
             "view": schematics_default_role,
         }
@@ -383,6 +385,15 @@ class Contract(BaseContract):
     value = ModelType(ContractValue)
     awardID = StringType(required=True)
     documents = ListType(ModelType(Document, required=True), default=list())
+
+    def get_role(self):
+        root = self.get_root()
+        request = root.request
+        if request.authenticated_role in ("tender_owner", "contract_supplier"):
+            role = "edit_{}".format(request.authenticated_role)
+        else:
+            role = request.authenticated_role
+        return role
 
     def __local_roles__(self):
         roles = {}

--- a/src/openprocurement/tender/core/utils.py
+++ b/src/openprocurement/tender/core/utils.py
@@ -577,19 +577,17 @@ def check_complaint_statuses_at_complaint_period_end(tender, now):
             check_complaints(award.complaints)
 
 
-def get_contract_supplier_permissions(tender):
+def get_contract_supplier_permissions(contract):
     """
     Set `upload_contract_document` permissions for award in `active` status owners
     """
     suppliers_permissions = []
-    if tender.get('bids', []) and tender.get('awards', []):
-        win_bids = jmespath.search("awards[?status=='active'].bid_id", tender._data) or []
-        for bid in tender.bids:
-            if bid.status == "active" and bid.id in win_bids:
-                suppliers_permissions.append(
-                    (Allow, "{}_{}".format(bid.owner, bid.owner_token), "upload_contract_documents")
-                )
-                suppliers_permissions.append((Allow, "{}_{}".format(bid.owner, bid.owner_token), "edit_contract"))
+    if not hasattr(contract, "__parent__") or 'bids' not in contract.__parent__:
+        return suppliers_permissions
+    win_bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract.awardID), contract.__parent__._data)[0]
+    win_bid = jmespath.search("bids[?id=='{}'].[owner,owner_token]".format(win_bid_id), contract.__parent__._data)[0]
+    bid_acl = "_".join(win_bid)
+    suppliers_permissions.extend([(Allow, bid_acl, "upload_contract_documents"), (Allow, bid_acl, "edit_contract")])
     return suppliers_permissions
 
 
@@ -598,8 +596,6 @@ def get_contract_supplier_roles(contract):
     if 'bids' not in contract.__parent__:
         return roles
     bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract.awardID), contract.__parent__)[0]
-    tokens = jmespath.search("bids[?id=='{}'].[owner,owner_token]".format(bid_id), contract.__parent__)
-    if tokens:
-        for item in tokens:
-            roles['_'.join(item)] = 'contract_supplier'
+    bid_data = jmespath.search("bids[?id=='{}'].[owner,owner_token]".format(bid_id), contract.__parent__)[0]
+    roles['_'.join(bid_data)] = 'contract_supplier'
     return roles

--- a/src/openprocurement/tender/core/utils.py
+++ b/src/openprocurement/tender/core/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import jmespath
 from decimal import Decimal
 from re import compile
 
@@ -573,3 +574,15 @@ def check_complaint_statuses_at_complaint_period_end(tender, now):
         complaint_period = getattr(award, "complaintPeriod", None)
         if complaint_period and complaint_period.endDate and complaint_period.endDate < now:
             check_complaints(award.complaints)
+
+
+def get_contract_supplier_roles(contract):
+    roles = {}
+    if 'bids' not in contract.__parent__:
+        return roles
+    bid_id = jmespath.search("awards[?id=='{}'].bid_id".format(contract.awardID), contract.__parent__)[0]
+    tokens = jmespath.search("bids[?id=='{}'].[owner,owner_token]".format(bid_id), contract.__parent__)
+    if tokens:
+        for item in tokens:
+            roles['_'.join(item)] = 'contract_supplier'
+    return roles

--- a/src/openprocurement/tender/core/validation.py
+++ b/src/openprocurement/tender/core/validation.py
@@ -1460,3 +1460,10 @@ def validate_complaint_type_change(request):
         complaint = request.validated["complaint"]
         if complaint.type == "claim":
             raise_operation_error(request, "Can't update claim to complaint")
+
+
+def validate_update_contract_status_by_supplier(request):
+    if request.authenticated_role == "contract_supplier":
+        data = request.validated["data"]
+        if "status" in data and data["status"] != "pending" or request.context.status != "pending.winnerSigning":
+            raise_operation_error(request, "Supplier can change status to `pending`")

--- a/src/openprocurement/tender/core/validation.py
+++ b/src/openprocurement/tender/core/validation.py
@@ -1465,7 +1465,7 @@ def validate_complaint_type_change(request):
 def validate_update_contract_status_by_supplier(request):
     if request.authenticated_role == "contract_supplier":
         data = request.validated["data"]
-        if "status" in data and data["status"] != "pending" or request.context.status != "pending.winnerSigning":
+        if "status" in data and data["status"] != "pending" or request.context.status != "pending.winner-signing":
             raise_operation_error(request, "Supplier can change status to `pending`")
 
 
@@ -1473,12 +1473,12 @@ def validate_role_for_contract_document_operation(request):
     if request.authenticated_role not in ("tender_owner", "contract_supplier",):
         raise_operation_error(request, "Can {} document only buyer or supplier".format(OPERATIONS.get(request.method)))
     if request.authenticated_role == "contract_supplier" and \
-            request.validated["contract"].status != "pending.winnerSigning":
+            request.validated["contract"].status != "pending.winner-signing":
         raise_operation_error(
             request, "Supplier can't {} document in current contract status".format(OPERATIONS.get(request.method))
         )
     if request.authenticated_role == "tender_owner" and \
-            request.validated["contract"].status == "pending.winnerSigning":
+            request.validated["contract"].status == "pending.winner-signing":
         raise_operation_error(
             request, "Tender onwer can't {} document in current contract status".format(OPERATIONS.get(request.method))
         )

--- a/src/openprocurement/tender/core/validation.py
+++ b/src/openprocurement/tender/core/validation.py
@@ -1467,3 +1467,18 @@ def validate_update_contract_status_by_supplier(request):
         data = request.validated["data"]
         if "status" in data and data["status"] != "pending" or request.context.status != "pending.winnerSigning":
             raise_operation_error(request, "Supplier can change status to `pending`")
+
+
+def validate_role_for_contract_document_operation(request):
+    if request.authenticated_role not in ("tender_owner", "contract_supplier",):
+        raise_operation_error(request, "Can {} document only buyer or supplier".format(OPERATIONS.get(request.method)))
+    if request.authenticated_role == "contract_supplier" and \
+            request.validated["contract"].status != "pending.winnerSigning":
+        raise_operation_error(
+            request, "Supplier can't {} document in current contract status".format(OPERATIONS.get(request.method))
+        )
+    if request.authenticated_role == "tender_owner" and \
+            request.validated["contract"].status == "pending.winnerSigning":
+        raise_operation_error(
+            request, "Tender onwer can't {} document in current contract status".format(OPERATIONS.get(request.method))
+        )

--- a/src/openprocurement/tender/esco/models.py
+++ b/src/openprocurement/tender/esco/models.py
@@ -56,7 +56,6 @@ from openprocurement.tender.core.utils import (
     extend_next_check_by_complaint_period_ends,
 )
 from openprocurement.tender.core.constants import CPV_ITEMS_CLASS_FROM
-from openprocurement.tender.core.utils import get_contract_supplier_permissions
 from openprocurement.tender.openua.models import Tender as OpenUATender
 from openprocurement.tender.openua.constants import COMPLAINT_SUBMIT_TIME, ENQUIRY_STAND_STILL_TIME, AUCTION_PERIOD_TIME
 from openprocurement.tender.openeu.models import (
@@ -663,9 +662,6 @@ class Tender(BaseTender):
 
         self._acl_cancellation_complaint(acl)
 
-        suppliers_permissions = get_contract_supplier_permissions(self)
-        if suppliers_permissions:
-            acl.extend(suppliers_permissions)
         return acl
 
     @serializable(serialized_name="enquiryPeriod", type=ModelType(EnquiryPeriod))

--- a/src/openprocurement/tender/esco/models.py
+++ b/src/openprocurement/tender/esco/models.py
@@ -56,6 +56,7 @@ from openprocurement.tender.core.utils import (
     extend_next_check_by_complaint_period_ends,
 )
 from openprocurement.tender.core.constants import CPV_ITEMS_CLASS_FROM
+from openprocurement.tender.core.utils import get_contract_supplier_permissions
 from openprocurement.tender.openua.models import Tender as OpenUATender
 from openprocurement.tender.openua.constants import COMPLAINT_SUBMIT_TIME, ENQUIRY_STAND_STILL_TIME, AUCTION_PERIOD_TIME
 from openprocurement.tender.openeu.models import (
@@ -655,10 +656,16 @@ class Tender(BaseTender):
         acl.extend(
             [
                 (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_complaint"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_contract"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "upload_contract_documents"),
             ]
         )
 
         self._acl_cancellation_complaint(acl)
+
+        suppliers_permissions = get_contract_supplier_permissions(self)
+        if suppliers_permissions:
+            acl.extend(suppliers_permissions)
         return acl
 
     @serializable(serialized_name="enquiryPeriod", type=ModelType(EnquiryPeriod))

--- a/src/openprocurement/tender/esco/tests/contract.py
+++ b/src/openprocurement/tender/esco/tests/contract.py
@@ -15,6 +15,11 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_status_by_owner,
     patch_tender_contract_status_by_others,
     patch_tender_contract_status_by_supplier,
+    create_tender_contract_document_by_supplier,
+    create_tender_contract_document_by_others,
+    put_tender_contract_document_by_supplier,
+    put_tender_contract_document_by_others,
+    patch_tender_contract_document_by_supplier,
 )
 
 from openprocurement.tender.openua.tests.contract_blanks import (
@@ -140,6 +145,12 @@ class TenderContractDocumentResourceTest(BaseESCOContentWebTest, TenderContractD
         contract = response.json["data"]
         self.contract_id = contract["id"]
         self.app.authorization = ("Basic", ("broker", ""))
+
+    test_create_tender_contract_document_by_supplier = snitch(create_tender_contract_document_by_supplier)
+    test_create_tender_contract_document_by_others = snitch(create_tender_contract_document_by_others)
+    test_put_tender_contract_document_by_supplier = snitch(put_tender_contract_document_by_supplier)
+    test_put_tender_contract_document_by_others = snitch(put_tender_contract_document_by_others)
+    test_patch_tender_contract_document_by_supplier = snitch(patch_tender_contract_document_by_supplier)
 
 
 def suite():

--- a/src/openprocurement/tender/esco/tests/contract.py
+++ b/src/openprocurement/tender/esco/tests/contract.py
@@ -11,6 +11,11 @@ from openprocurement.tender.belowthreshold.tests.contract import (
     TenderContractResourceTestMixin,
     TenderContractDocumentResourceTestMixin,
 )
+from openprocurement.tender.belowthreshold.tests.contract_blanks import (
+    patch_tender_contract_status_by_owner,
+    patch_tender_contract_status_by_others,
+    patch_tender_contract_status_by_supplier,
+)
 
 from openprocurement.tender.openua.tests.contract_blanks import (
     # TenderContractResourceTest
@@ -102,6 +107,9 @@ class TenderContractResourceTest(BaseESCOContentWebTest, TenderContractResourceT
     test_create_tender_contract = snitch(create_tender_contract)
     test_patch_tender_contract_datesigned = snitch(patch_tender_contract_datesigned)
     test_patch_tender_contract = snitch(patch_tender_contract)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderContractDocumentResourceTest(BaseESCOContentWebTest, TenderContractDocumentResourceTestMixin):

--- a/src/openprocurement/tender/esco/views/contract.py
+++ b/src/openprocurement/tender/esco/views/contract.py
@@ -9,6 +9,7 @@ from openprocurement.tender.core.validation import (
     validate_update_contract_value_with_award,
     validate_update_contract_value_amount,
     validate_update_contract_value_net_required,
+    validate_update_contract_status_by_supplier,
 )
 from openprocurement.tender.esco.validation import validate_update_contract_value_esco
 from openprocurement.tender.openeu.views.contract import TenderAwardContractResource as TenderEUContractResource
@@ -33,6 +34,7 @@ class TenderESCOContractResource(TenderEUContractResource):
         validators=(
             validate_patch_contract_data,
             validate_contract_operation_not_in_allowed_status,
+            validate_update_contract_status_by_supplier,
             validate_update_contract_only_for_active_lots,
             validate_contract_update_with_accepted_complaint,
             validate_update_contract_value_esco,

--- a/src/openprocurement/tender/esco/views/contract.py
+++ b/src/openprocurement/tender/esco/views/contract.py
@@ -29,7 +29,7 @@ class TenderESCOContractResource(TenderEUContractResource):
 
     @json_view(
         content_type="application/json",
-        permission="edit_tender",
+        permission="edit_contract",
         validators=(
             validate_patch_contract_data,
             validate_contract_operation_not_in_allowed_status,

--- a/src/openprocurement/tender/limited/tests/contract.py
+++ b/src/openprocurement/tender/limited/tests/contract.py
@@ -36,6 +36,9 @@ from openprocurement.tender.limited.tests.contract_blanks import (
     patch_tender_contract,
     tender_contract_signature_date,
     award_id_change_is_not_allowed,
+    create_tender_contract_document,
+    patch_tender_contract_document,
+    put_tender_contract_document,
 )
 from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_value_vat_not_included,
@@ -386,6 +389,10 @@ class TenderContractDocumentResourceTest(BaseTenderContentWebTest, TenderContrac
         self.create_award()
         response = self.app.get("/tenders/{}/contracts".format(self.tender_id))
         self.contract_id = response.json["data"][0]["id"]
+
+    test_create_tender_contract_document = snitch(create_tender_contract_document)
+    test_patch_tender_contract_document = snitch(patch_tender_contract_document)
+    test_put_tender_contract_document = snitch(put_tender_contract_document)
 
 
 class TenderContractNegotiationDocumentResourceTest(TenderContractDocumentResourceTest):

--- a/src/openprocurement/tender/openeu/models.py
+++ b/src/openprocurement/tender/openeu/models.py
@@ -54,7 +54,6 @@ from openprocurement.tender.core.utils import (
     calculate_complaint_business_date,
     calculate_clarifications_business_date,
     extend_next_check_by_complaint_period_ends,
-    get_contract_supplier_permissions,
 )
 from openprocurement.tender.belowthreshold.models import Tender as BaseTender
 from openprocurement.tender.core.validation import validate_lotvalue_value, validate_relatedlot
@@ -652,9 +651,6 @@ class Tender(BaseTender):
             ]
         )
 
-        suppliers_permissions = get_contract_supplier_permissions(self)
-        if suppliers_permissions:
-            acl.extend(suppliers_permissions)
         self._acl_cancellation_complaint(acl)
         return acl
 

--- a/src/openprocurement/tender/openeu/models.py
+++ b/src/openprocurement/tender/openeu/models.py
@@ -54,6 +54,7 @@ from openprocurement.tender.core.utils import (
     calculate_complaint_business_date,
     calculate_clarifications_business_date,
     extend_next_check_by_complaint_period_ends,
+    get_contract_supplier_permissions,
 )
 from openprocurement.tender.belowthreshold.models import Tender as BaseTender
 from openprocurement.tender.core.validation import validate_lotvalue_value, validate_relatedlot
@@ -646,8 +647,14 @@ class Tender(BaseTender):
         acl.extend(
             [
                 (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_complaint"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_contract"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "upload_contract_documents"),
             ]
         )
+
+        suppliers_permissions = get_contract_supplier_permissions(self)
+        if suppliers_permissions:
+            acl.extend(suppliers_permissions)
         self._acl_cancellation_complaint(acl)
         return acl
 

--- a/src/openprocurement/tender/openeu/tests/contract.py
+++ b/src/openprocurement/tender/openeu/tests/contract.py
@@ -9,7 +9,12 @@ from openprocurement.tender.belowthreshold.tests.contract import (
     TenderContractResourceTestMixin,
     TenderContractDocumentResourceTestMixin,
 )
-from openprocurement.tender.belowthreshold.tests.contract_blanks import patch_tender_contract_value
+from openprocurement.tender.belowthreshold.tests.contract_blanks import (
+    patch_tender_contract_value,
+    patch_tender_contract_status_by_owner,
+    patch_tender_contract_status_by_others,
+    patch_tender_contract_status_by_supplier,
+)
 
 from openprocurement.tender.openua.tests.contract_blanks import (
     # TenderContractResourceTest
@@ -62,6 +67,9 @@ class TenderContractResourceTest(BaseTenderContentWebTest, TenderContractResourc
     test_patch_tender_contract_datesigned = snitch(patch_tender_contract_datesigned)
     test_patch_tender_contract = snitch(patch_tender_contract)
     test_patch_tender_contract_value = snitch(patch_tender_contract_value)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderContractDocumentResourceTest(BaseTenderContentWebTest, TenderContractDocumentResourceTestMixin):

--- a/src/openprocurement/tender/openeu/tests/contract.py
+++ b/src/openprocurement/tender/openeu/tests/contract.py
@@ -14,6 +14,11 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_status_by_owner,
     patch_tender_contract_status_by_others,
     patch_tender_contract_status_by_supplier,
+    create_tender_contract_document_by_supplier,
+    create_tender_contract_document_by_others,
+    put_tender_contract_document_by_supplier,
+    put_tender_contract_document_by_others,
+    patch_tender_contract_document_by_supplier,
 )
 
 from openprocurement.tender.openua.tests.contract_blanks import (
@@ -101,6 +106,12 @@ class TenderContractDocumentResourceTest(BaseTenderContentWebTest, TenderContrac
         contract = response.json["data"]
         self.contract_id = contract["id"]
         self.app.authorization = ("Basic", ("broker", ""))
+
+    test_create_tender_contract_document_by_supplier = snitch(create_tender_contract_document_by_supplier)
+    test_create_tender_contract_document_by_others = snitch(create_tender_contract_document_by_others)
+    test_put_tender_contract_document_by_supplier = snitch(put_tender_contract_document_by_supplier)
+    test_put_tender_contract_document_by_others = snitch(put_tender_contract_document_by_others)
+    test_patch_tender_contract_document_by_supplier = snitch(patch_tender_contract_document_by_supplier)
 
 
 def suite():

--- a/src/openprocurement/tender/openua/models.py
+++ b/src/openprocurement/tender/openua/models.py
@@ -57,7 +57,6 @@ from openprocurement.tender.core.utils import (
     calculate_complaint_business_date,
     calculate_clarifications_business_date,
     extend_next_check_by_complaint_period_ends,
-    get_contract_supplier_permissions,
 )
 from openprocurement.tender.core.validation import validate_lotvalue_value, validate_relatedlot
 from openprocurement.tender.belowthreshold.models import Tender as BaseTender
@@ -616,9 +615,7 @@ class Tender(BaseTender):
                 (Allow, "{}_{}".format(self.owner, self.owner_token), "upload_contract_documents"),
             ]
         )
-        suppliers_permissions = get_contract_supplier_permissions(self)
-        if suppliers_permissions:
-            acl.extend(suppliers_permissions)
+
         self._acl_cancellation_complaint(acl)
         return acl
 

--- a/src/openprocurement/tender/openua/models.py
+++ b/src/openprocurement/tender/openua/models.py
@@ -57,6 +57,7 @@ from openprocurement.tender.core.utils import (
     calculate_complaint_business_date,
     calculate_clarifications_business_date,
     extend_next_check_by_complaint_period_ends,
+    get_contract_supplier_permissions,
 )
 from openprocurement.tender.core.validation import validate_lotvalue_value, validate_relatedlot
 from openprocurement.tender.belowthreshold.models import Tender as BaseTender
@@ -611,9 +612,13 @@ class Tender(BaseTender):
         acl.extend(
             [
                 (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_complaint"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "edit_contract"),
+                (Allow, "{}_{}".format(self.owner, self.owner_token), "upload_contract_documents"),
             ]
         )
-
+        suppliers_permissions = get_contract_supplier_permissions(self)
+        if suppliers_permissions:
+            acl.extend(suppliers_permissions)
         self._acl_cancellation_complaint(acl)
         return acl
 

--- a/src/openprocurement/tender/openua/tests/contract.py
+++ b/src/openprocurement/tender/openua/tests/contract.py
@@ -22,6 +22,11 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_status_by_owner,
     patch_tender_contract_status_by_others,
     patch_tender_contract_status_by_supplier,
+    create_tender_contract_document_by_supplier,
+    create_tender_contract_document_by_others,
+    put_tender_contract_document_by_supplier,
+    put_tender_contract_document_by_others,
+    patch_tender_contract_document_by_supplier,
 )
 
 
@@ -130,6 +135,12 @@ class TenderContractDocumentResourceTest(BaseTenderUAContentWebTest, TenderContr
         contract = response.json["data"]
         self.contract_id = contract["id"]
         self.app.authorization = auth
+
+    test_create_tender_contract_document_by_supplier = snitch(create_tender_contract_document_by_supplier)
+    test_create_tender_contract_document_by_others = snitch(create_tender_contract_document_by_others)
+    test_put_tender_contract_document_by_supplier = snitch(put_tender_contract_document_by_supplier)
+    test_put_tender_contract_document_by_others = snitch(put_tender_contract_document_by_others)
+    test_patch_tender_contract_document_by_supplier = snitch(patch_tender_contract_document_by_supplier)
 
 
 def suite():

--- a/src/openprocurement/tender/openua/tests/contract.py
+++ b/src/openprocurement/tender/openua/tests/contract.py
@@ -19,6 +19,9 @@ from openprocurement.tender.openua.tests.contract_blanks import (
 from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_value_vat_not_included,
     patch_tender_contract_value,
+    patch_tender_contract_status_by_owner,
+    patch_tender_contract_status_by_others,
+    patch_tender_contract_status_by_supplier,
 )
 
 
@@ -55,6 +58,9 @@ class TenderContractResourceTest(BaseTenderUAContentWebTest, TenderContractResou
     test_patch_tender_contract_datesigned = snitch(patch_tender_contract_datesigned)
     test_patch_tender_contract = snitch(patch_tender_contract)
     test_patch_tender_contract_value = snitch(patch_tender_contract_value)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderContractVATNotIncludedResourceTest(BaseTenderUAContentWebTest, TenderContractResourceTestMixin):
@@ -92,6 +98,9 @@ class TenderContractVATNotIncludedResourceTest(BaseTenderUAContentWebTest, Tende
         self.create_award()
 
     test_patch_tender_contract_value_vat_not_included = snitch(patch_tender_contract_value_vat_not_included)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderContractDocumentResourceTest(BaseTenderUAContentWebTest, TenderContractDocumentResourceTestMixin):

--- a/src/openprocurement/tender/openua/views/contract.py
+++ b/src/openprocurement/tender/openua/views/contract.py
@@ -26,7 +26,7 @@ from openprocurement.tender.openua.validation import validate_contract_update_wi
 class TenderUaAwardContractResource(TenderAwardContractResource):
     @json_view(
         content_type="application/json",
-        permission="edit_tender",
+        permission="edit_contract",
         validators=(
             validate_patch_contract_data,
             validate_contract_operation_not_in_allowed_status,

--- a/src/openprocurement/tender/openua/views/contract.py
+++ b/src/openprocurement/tender/openua/views/contract.py
@@ -11,6 +11,7 @@ from openprocurement.tender.core.validation import (
     validate_update_contract_value_with_award,
     validate_update_contract_value_amount,
     validate_update_contract_value_net_required,
+    validate_update_contract_status_by_supplier,
 )
 from openprocurement.tender.core.utils import save_tender, apply_patch, optendersresource
 from openprocurement.tender.openua.validation import validate_contract_update_with_accepted_complaint
@@ -30,6 +31,7 @@ class TenderUaAwardContractResource(TenderAwardContractResource):
         validators=(
             validate_patch_contract_data,
             validate_contract_operation_not_in_allowed_status,
+            validate_update_contract_status_by_supplier,
             validate_update_contract_only_for_active_lots,
             validate_contract_update_with_accepted_complaint,
             validate_update_contract_value,
@@ -44,9 +46,9 @@ class TenderUaAwardContractResource(TenderAwardContractResource):
         """
         contract_status = self.request.context.status
         apply_patch(self.request, save=False, src=self.request.context.serialize())
-        if contract_status != self.request.context.status and (
-            contract_status != "pending" or self.request.context.status != "active"
-        ):
+        if contract_status != self.request.context.status and \
+                (contract_status not in ("pending", "pending.winnerSigning",) or \
+                self.request.context.status not in ("active", "pending", "pending.winnerSigning",)):
             raise_operation_error(self.request, "Can't update contract status")
         if self.request.context.status == "active" and not self.request.context.dateSigned:
             self.request.context.dateSigned = get_now()

--- a/src/openprocurement/tender/openua/views/contract.py
+++ b/src/openprocurement/tender/openua/views/contract.py
@@ -47,8 +47,8 @@ class TenderUaAwardContractResource(TenderAwardContractResource):
         contract_status = self.request.context.status
         apply_patch(self.request, save=False, src=self.request.context.serialize())
         if contract_status != self.request.context.status and \
-                (contract_status not in ("pending", "pending.winnerSigning",) or \
-                self.request.context.status not in ("active", "pending", "pending.winnerSigning",)):
+                (contract_status not in ("pending", "pending.winner-signing",) or \
+                self.request.context.status not in ("active", "pending", "pending.winner-signing",)):
             raise_operation_error(self.request, "Can't update contract status")
         if self.request.context.status == "active" and not self.request.context.dateSigned:
             self.request.context.dateSigned = get_now()

--- a/src/openprocurement/tender/openua/views/contract_document.py
+++ b/src/openprocurement/tender/openua/views/contract_document.py
@@ -37,7 +37,7 @@ class TenderUaAwardContractDocumentResource(TenderAwardContractDocumentResource)
             ]
         ):
             raise_operation_error(self.request, "Can {} document only in active lot status".format(operation))
-        if self.request.validated["contract"].status not in ["pending", "active"]:
+        if self.request.validated["contract"].status not in ["pending", "pending.winnerSigning", "active"]:
             raise_operation_error(self.request, "Can't {} document in current contract status".format(operation))
         if any(
             [

--- a/src/openprocurement/tender/openua/views/contract_document.py
+++ b/src/openprocurement/tender/openua/views/contract_document.py
@@ -37,7 +37,7 @@ class TenderUaAwardContractDocumentResource(TenderAwardContractDocumentResource)
             ]
         ):
             raise_operation_error(self.request, "Can {} document only in active lot status".format(operation))
-        if self.request.validated["contract"].status not in ["pending", "pending.winnerSigning", "active"]:
+        if self.request.validated["contract"].status not in ["pending", "pending.winner-signing", "active"]:
             raise_operation_error(self.request, "Can't {} document in current contract status".format(operation))
         if any(
             [

--- a/src/openprocurement/tender/openuadefense/tests/contract.py
+++ b/src/openprocurement/tender/openuadefense/tests/contract.py
@@ -21,6 +21,9 @@ from openprocurement.tender.openuadefense.tests.base import BaseTenderUAContentW
 from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_value_vat_not_included,
     patch_tender_contract_value,
+    patch_tender_contract_status_by_owner,
+    patch_tender_contract_status_by_others,
+    patch_tender_contract_status_by_supplier,
 )
 
 
@@ -56,6 +59,9 @@ class TenderContractResourceTest(BaseTenderUAContentWebTest, TenderContractResou
     test_create_tender_contract = snitch(create_tender_contract)
     test_patch_tender_contract = snitch(patch_tender_contract)
     test_patch_tender_contract_value = snitch(patch_tender_contract_value)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderContractVATNotIncludedResourceTest(BaseTenderUAContentWebTest, TenderContractResourceTestMixin):
@@ -94,6 +100,9 @@ class TenderContractVATNotIncludedResourceTest(BaseTenderUAContentWebTest, Tende
         self.create_award()
 
     test_patch_tender_contract_value_vat_not_included = snitch(patch_tender_contract_value_vat_not_included)
+    test_patch_tender_contract_status_by_owner = snitch(patch_tender_contract_status_by_owner)
+    test_patch_tender_contract_status_by_others = snitch(patch_tender_contract_status_by_others)
+    test_patch_tender_contract_status_by_supplier = snitch(patch_tender_contract_status_by_supplier)
 
 
 class TenderContractDocumentResourceTest(BaseTenderUAContentWebTest, TenderContractDocumentResourceTestMixin):

--- a/src/openprocurement/tender/openuadefense/tests/contract.py
+++ b/src/openprocurement/tender/openuadefense/tests/contract.py
@@ -24,6 +24,11 @@ from openprocurement.tender.belowthreshold.tests.contract_blanks import (
     patch_tender_contract_status_by_owner,
     patch_tender_contract_status_by_others,
     patch_tender_contract_status_by_supplier,
+    create_tender_contract_document_by_supplier,
+    create_tender_contract_document_by_others,
+    put_tender_contract_document_by_supplier,
+    put_tender_contract_document_by_others,
+    patch_tender_contract_document_by_supplier,
 )
 
 
@@ -132,6 +137,12 @@ class TenderContractDocumentResourceTest(BaseTenderUAContentWebTest, TenderContr
         contract = response.json["data"]
         self.contract_id = contract["id"]
         self.app.authorization = auth
+
+    test_create_tender_contract_document_by_supplier = snitch(create_tender_contract_document_by_supplier)
+    test_create_tender_contract_document_by_others = snitch(create_tender_contract_document_by_others)
+    test_put_tender_contract_document_by_supplier = snitch(put_tender_contract_document_by_supplier)
+    test_put_tender_contract_document_by_others = snitch(put_tender_contract_document_by_others)
+    test_patch_tender_contract_document_by_supplier = snitch(patch_tender_contract_document_by_supplier)
 
 
 def suite():


### PR DESCRIPTION
#  Концепція підписання договору між замовником та постачальником-переможцем аукціону

## Процес підписання
Процес підписання договору між замовником (`tender owner`) та постачальником (`supplier` відбувається у об’єкті `Contract` у статусі `pending`. 

#### Workflow:
1. Перевірка, чи **Contract** у статусі `pending`
1. Визначення ***постачальника***. Перевірка, чи його **Bid** та **Award** у статусі `active`
1. Зміна ***замовником*** статусу контракту до `pending.winner-signing` .
1. Завантаження ***постачальником*** документів та ЄЦП (підписання контракту);
1. Зміна ***постачальником*** статусу до `pending`;
1. Завантаження ***замовником*** документів та ЄЦП (підписання контракту);
1. Зміна ***замовником статусу*** контракту до `active`.

#### Підсумок:
Для створення процесу підписання та унеможливлення підписання контракту кимось іншим, окрім замовника та постачальника, внесли наступні зміни:
+ використали існуючу роль `tender_owner` та ввели нову  - `contract_supplier`;
+ ввели поняття локальні ролі у **Contract** ( *`__local_roles__`*), додали туди `contract_supplier` 
+ Роль `edit` розділили на моделі **Contract** на три:
    +  `edit_admins`;
    +  `edit_contract_supplier`;
    +  `edit_tender_owner`.
+ надали дозволи (`permissions`) для `tender_owner` i `contract_supplier`, і вони однакові :
   +  `upload_contract_documents` ;
   +  `edit_contract`.
+ створили статус **`pending.winner-signing`** та валідації до нього:
    + `validate_role_for_contract_document_operation`,  
    + `validate_update_contract_status_by_supplier`,
    + `validate_contract_document` (існуюча, змінена).


## Зміни:
### Модель Contract:

Для індентифікації постачальника необхідно знайти пропозицію (**Bid**), чий власник виграв аукціон.  При тому і **Bid**, і **Award** повинні бути у статусі `active`. 

Цим керуючись, в  `core` утилітах додали функцію  `get_contract_supplier_roles` - присвоювання локальної ролі `contract_supplier` власнику `Bid`:

*Окільки намає змоги видати постачальнику токен для контракту напряму, ми використали токен його виграшної пропозиції (**Bid**).*

https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/4fe6ee9b398a9044b173715bc493be44ad30a1b9/src/openprocurement/tender/core/utils.py#L449-L458

У самій моделі **Contract** перевизначили `__local_roles__` ролями постачальника:

https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/4fe6ee9b398a9044b173715bc493be44ad30a1b9/src/openprocurement/tender/core/models.py#L396-L399

Тут і змінили метод `get_role`, що повертає відповідну роль `edit` для замовника та постачальника:

https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/4fe6ee9b398a9044b173715bc493be44ad30a1b9/src/openprocurement/tender/core/models.py#L387-L394

Зміни внесли для всіх типів  **Contract** та **Tender**:

*Зміни у класі **Options**, для closeFrameworkAgreementSelectionUA - сontract.csv файлі.* 
https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/4fe6ee9b398a9044b173715bc493be44ad30a1b9/src/openprocurement/tender/core/models.py#L376-L378


### Модель Tender:
У `core` утиліти додали функцію   `get_contract_supplier_permissions` - визначенні дозволів постачальників `contract_supplier_permissions` *(керується принципом роботи, описаним над  `get_contract_supplier_roles`)*. Надали постачальнику дозволи `upload_contract_documents` та `edit_contract`.

https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/4fe6ee9b398a9044b173715bc493be44ad30a1b9/src/openprocurement/tender/core/utils.py#L433-L446

У моделі **Tender** перевизначили список контролю-доступу новими ролями та дозволами постачальника, аналогічні ( `upload_contract_documents` та `edit_contract`) дали і замовнику.
https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/4fe6ee9b398a9044b173715bc493be44ad30a1b9/src/openprocurement/tender/core/models.py#L1477-L1490

### Статус  `pending.winner-signing`:
Створили статус `pending.winner-signing`:
+ замовник може перемкнути на цей статус;
+ під час цього статусу постачальник-переможець матиме можливість завантажити документи та підписати контракт.
https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/f90bf3dd18cb0bab3ab6c7a0a5d2078c9fd83107/src/openprocurement/api/models.py#L676

Перевизначили можливість оновити всі типи контрактів (PATCH) у всіх типах моделі **Tender** з `permission="edit_contract"` у статусі  `pending.winner-signing`:  
https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/f90bf3dd18cb0bab3ab6c7a0a5d2078c9fd83107/src/openprocurement/tender/belowthreshold/views/contract.py#L85-L89

Створили валідації статусу:
https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/f90bf3dd18cb0bab3ab6c7a0a5d2078c9fd83107/src/openprocurement/tender/core/validation.py#L1208-L1213

https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/f90bf3dd18cb0bab3ab6c7a0a5d2078c9fd83107/src/openprocurement/tender/core/validation.py#L1215-L1227
