### PR TITLE
Added documentOf option.

### DIFF
--- a/src/openprocurement/tender/belowthreshold/tests/award.py
+++ b/src/openprocurement/tender/belowthreshold/tests/award.py
@@ -64,6 +64,7 @@ from openprocurement.tender.belowthreshold.tests.award_blanks import (
     # TenderAwardDocumentResourceTest
     not_found_award_document,
     create_tender_award_document,
+    put_tender_json_award_document_of_document,
     put_tender_award_document,
     patch_tender_award_document,
     create_award_document_bot,
@@ -96,6 +97,7 @@ class TenderAwardDocumentResourceTestMixin(object):
     test_not_found_award_document = snitch(not_found_award_document)
     test_create_tender_award_document = snitch(create_tender_award_document)
     test_put_tender_award_document = snitch(put_tender_award_document)
+    test_put_tender_json_award_document_of_document = snitch(put_tender_json_award_document_of_document)
     test_patch_tender_award_document = snitch(patch_tender_award_document)
     test_create_award_document_bot = snitch(create_award_document_bot)
     test_patch_not_author = snitch(patch_not_author)

--- a/src/openprocurement/tender/belowthreshold/tests/base.py
+++ b/src/openprocurement/tender/belowthreshold/tests/base.py
@@ -84,6 +84,15 @@ test_tender_data = {
     "procurementMethodType": "belowThreshold",
     "milestones": test_milestones,
 }
+
+test_tender_document_data = {
+    "url": "http://ds.prozorro.local/get/b97562e3f33c493297fd14dd6d8c50f0?KeyID=a8968c46&Signature=3OV7QC7f%2ByfcGTvpy0tf%2FaM%2BFRI6kkg1ImfEJlfAx5qi%2FLY7IIj7TFqtxgaPrzdd%2BWIOCe3O5Q7WhXkOdCB9CQ%3D%3D",
+    "documentType":"tenderNotice",
+    "title": "Notice.pdf",
+    "hash": "md5:00000000000000000000000000000000",
+    "format": "application/pdf"
+}
+
 if SANDBOX_MODE:
     test_tender_data["procurementMethodDetails"] = "quick, accelerator=1440"
 test_features_tender_data = test_tender_data.copy()

--- a/src/openprocurement/tender/belowthreshold/tests/document.py
+++ b/src/openprocurement/tender/belowthreshold/tests/document.py
@@ -11,6 +11,7 @@ from openprocurement.tender.belowthreshold.tests.document_blanks import (
     create_tender_document,
     put_tender_document,
     patch_tender_document,
+    put_tender_json_document_of_document,
     # TenderDocumentWithDSResourceTest
     create_tender_document_error,
     create_tender_document_json_invalid,
@@ -33,6 +34,7 @@ class TenderDocumentWithDSResourceTestMixin(object):
     test_create_tender_document_json_invalid = snitch(create_tender_document_json_invalid)
     test_create_tender_document_json = snitch(create_tender_document_json)
     test_put_tender_document_json = snitch(put_tender_document_json)
+    test_put_tender_json_document_of_document = snitch(put_tender_json_document_of_document)
 
 
 class TenderDocumentResourceTest(TenderContentWebTest, TenderDocumentResourceTestMixin):

--- a/src/openprocurement/tender/cfaselectionua/tests/award.py
+++ b/src/openprocurement/tender/cfaselectionua/tests/award.py
@@ -3,7 +3,10 @@ import unittest
 from copy import deepcopy
 
 from openprocurement.api.tests.base import snitch
-from openprocurement.tender.belowthreshold.tests.award_blanks import patch_tender_lot_award_lots_none
+from openprocurement.tender.belowthreshold.tests.award_blanks import (
+    patch_tender_lot_award_lots_none,
+    put_tender_json_award_document_of_document,
+)
 from openprocurement.tender.cfaselectionua.adapters.configurator import TenderCfaSelectionUAConfigurator
 from openprocurement.tender.cfaselectionua.tests.base import (
     TenderContentWebTest,
@@ -53,6 +56,7 @@ class TenderAwardResourceTestMixin(object):
 class TenderAwardDocumentResourceTestMixin(object):
     test_not_found_award_document = snitch(not_found_award_document)
     test_create_tender_award_document = snitch(create_tender_award_document)
+    test_put_tender_json_award_document_of_document = snitch(put_tender_json_award_document_of_document)
     test_put_tender_award_document = snitch(put_tender_award_document)
     test_patch_tender_award_document = snitch(patch_tender_award_document)
     test_create_award_document_bot = snitch(create_award_document_bot)

--- a/src/openprocurement/tender/cfaselectionua/tests/document.py
+++ b/src/openprocurement/tender/cfaselectionua/tests/document.py
@@ -10,6 +10,7 @@ from openprocurement.tender.belowthreshold.tests.document_blanks import (
     create_tender_document_json_invalid,
     create_tender_document_json,
     put_tender_document_json,
+    put_tender_json_document_of_document,
 )
 
 from openprocurement.tender.cfaselectionua.tests.document_blanks import (
@@ -34,6 +35,7 @@ class TenderDocumentWithDSResourceTestMixin(object):
     test_create_tender_document_json_invalid = snitch(create_tender_document_json_invalid)
     test_create_tender_document_json = snitch(create_tender_document_json)
     test_put_tender_document_json = snitch(put_tender_document_json)
+    test_put_tender_json_document_of_document = snitch(put_tender_json_document_of_document)
 
 
 class TenderDocumentResourceTest(TenderContentWebTest, TenderDocumentResourceTestMixin):

--- a/src/openprocurement/tender/competitivedialogue/tests/stage1/document.py
+++ b/src/openprocurement/tender/competitivedialogue/tests/stage1/document.py
@@ -12,6 +12,7 @@ from openprocurement.tender.competitivedialogue.tests.base import (
 from openprocurement.tender.competitivedialogue.tests.stage1.document_blanks import (
     put_tender_document,
     patch_tender_document,
+    put_tender_json_document_of_document,
 )
 
 #  _____________________________________________________________________
@@ -61,7 +62,7 @@ class DialogUADocumentResourceTest(BaseCompetitiveDialogUAContentWebTest, Tender
 
     test_put_tender_document = snitch(put_tender_document)
     test_patch_tender_document = snitch(patch_tender_document)
-
+    test_put_tender_json_document_of_document =snitch(put_tender_json_document_of_document)
 
 class DialogUADocumentWithDSResourceTest(DialogUADocumentResourceTest):
     docservice = True

--- a/src/openprocurement/tender/competitivedialogue/tests/stage2/document.py
+++ b/src/openprocurement/tender/competitivedialogue/tests/stage2/document.py
@@ -12,6 +12,7 @@ from openprocurement.tender.competitivedialogue.tests.base import (
 from openprocurement.tender.competitivedialogue.tests.stage1.document_blanks import (
     put_tender_document,
     patch_tender_document,
+    put_tender_json_document_of_document,
 )
 
 #  _____________________________________________________________________
@@ -49,7 +50,6 @@ class TenderStage2EUDocumentResourceTest(BaseCompetitiveDialogEUStage2ContentWeb
     test_put_tender_document = snitch(put_tender_document)
     test_patch_tender_document = snitch(patch_tender_document)
 
-
 class TenderStage2DocumentWithDSResourceTest(TenderStage2EUDocumentResourceTest, TenderDocumentResourceTestMixin):
     docservice = True
 
@@ -65,7 +65,7 @@ class TenderStage2UADocumentResourceTest(BaseCompetitiveDialogUAStage2ContentWeb
 
     test_put_tender_document = snitch(put_tender_document)
     test_patch_tender_document = snitch(patch_tender_document)
-
+    test_put_tender_json_document_of_document = snitch(put_tender_json_document_of_document)
 
 class TenderStage2UADocumentWithDSResourceTest(TenderStage2UADocumentResourceTest, TenderDocumentResourceTestMixin):
     docservice = True

--- a/src/openprocurement/tender/core/models.py
+++ b/src/openprocurement/tender/core/models.py
@@ -148,7 +148,9 @@ class ComplaintModelType(ModelType):
 
 
 class Document(BaseDocument):
-    documentOf = StringType(required=True, choices=["tender", "item", "lot"], default="tender")
+    documentOf = StringType(required=True, choices=[
+                            "tender", "item", "lot",  "document"], default="tender")
+
 
     def validate_relatedItem(self, data, relatedItem):
         if not relatedItem and data.get("documentOf") in ["item", "lot"]:
@@ -160,6 +162,8 @@ class Document(BaseDocument):
                 raise ValidationError(u"relatedItem should be one of lots")
             if data.get("documentOf") == "item" and relatedItem not in [i.id for i in tender.items if i]:
                 raise ValidationError(u"relatedItem should be one of items")
+            if data.get("documentOf") == "document" and relatedItem not in [i.id for i in tender.documents]:
+                raise ValidationError(u"relatedItem should be one of documents")
 
 
 class ConfidentialDocument(Document):


### PR DESCRIPTION
#  Пов'язаність документів
Даний функціонал є частиною функціоналу підписання контракту постачальником.

Для розширення системи функціоналом Е-Контрактингу у даному PR внесли наступні зміни:
### Модель Document (Tender):
Для поєднання нових типів документів між собою було введено тип підпорядкування поля **`documentOf`** – **`document`**, Він надасть можливість пов’язати між собою відповідні документи об'єкту **Tender** для генерації документу **Contract**.
 https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/dffb0b98bfbfcd11e60186414b9f93d0cb7e4eb3/src/openprocurement/tender/core/models.py#L151-L152
https://github.com/openprocurement/ProzorroUKR-openprocurement.api/blob/dffb0b98bfbfcd11e60186414b9f93d0cb7e4eb3/src/openprocurement/tender/core/models.py#L165-L166